### PR TITLE
Clean up initializer comments in service classes

### DIFF
--- a/App/FreshWall/FreshWallApp/Services/ClientService.swift
+++ b/App/FreshWall/FreshWallApp/Services/ClientService.swift
@@ -14,8 +14,7 @@ struct ClientService: ClientServiceProtocol {
     private let firestore: Firestore
     private let session: UserSession
 
-    /// Initializes the service with the given UserService for team context.
-    /// Initializes the service with a Firestore instance and UserService for team context.
+    /// Initializes the service with a `Firestore` instance and `UserSession` for team context.
     init(firestore: Firestore, session: UserSession) {
         self.firestore = firestore
         self.session = session

--- a/App/FreshWall/FreshWallApp/Services/IncidentService.swift
+++ b/App/FreshWall/FreshWallApp/Services/IncidentService.swift
@@ -17,8 +17,7 @@ struct IncidentService: IncidentServiceProtocol {
     private let firestore: Firestore
     private let session: UserSession
 
-    /// Initializes the service with the given UserService for team context.
-    /// Initializes the service with a Firestore instance and UserService for team context.
+    /// Initializes the service with a `Firestore` instance and `UserSession` for team context.
     init(firestore: Firestore, session: UserSession) {
         self.firestore = firestore
         self.session = session

--- a/App/FreshWall/FreshWallApp/Services/MemberService.swift
+++ b/App/FreshWall/FreshWallApp/Services/MemberService.swift
@@ -14,8 +14,7 @@ struct MemberService: MemberServiceProtocol {
     private let firestore: Firestore
     private let session: UserSession
 
-    /// Initializes the service with the given UserService for team context.
-    /// Initializes the service with a Firestore instance and UserService for team context.
+    /// Initializes the service with a `Firestore` instance and `UserSession` for team context.
     init(firestore: Firestore, session: UserSession) {
         self.firestore = firestore
         self.session = session


### PR DESCRIPTION
## Summary
- simplify initializer documentation in `ClientService`
- simplify initializer documentation in `MemberService`
- simplify initializer documentation in `IncidentService`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850f7198f0c832fa934b0bb99b5063d