### PR TITLE
Switch iOS testing docs to Swift Testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ AI agents should understand and respect the separation between frontend (Swift c
 
 ### iOS Tests
 
-- Use XCTest for unit tests
+- Use Swift Testing for unit tests
 - Test files must match the name of the class being tested (`XyzViewModelTests.swift`)
 - PreviewProvider usage is encouraged for SwiftUI views
 


### PR DESCRIPTION
## Summary
- reference Swift Testing instead of XCTest in **AGENTS.md**

## Testing
- `npm run lint` *(fails: ENOENT no eslint config)*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6850f757be40832faf0324495148c827