### PR TITLE
Add workflow for TypeScript functions tests

### DIFF
--- a/.github/workflows/functions-tests.yml
+++ b/.github/workflows/functions-tests.yml
@@ -1,0 +1,20 @@
+name: Functions Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Firebase/functions
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test

--- a/Firebase/functions/package.json
+++ b/Firebase/functions/package.json
@@ -4,6 +4,7 @@
     "lint": "eslint --ext .js,.ts .",
     "build": "tsc",
     "build:watch": "tsc --watch",
+    "test": "npm run lint && npm run build",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",


### PR DESCRIPTION
## Summary
- add workflow to run lint/build for Firebase functions
- set `npm test` script to run lint and build

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6850fe84e880832f9d49375f8bfba4cd