### PR TITLE
Fix repository type name

### DIFF
--- a/App/FreshWall/FreshWallApp/Clients/Repositories/ClientsRepository.swift
+++ b/App/FreshWall/FreshWallApp/Clients/Repositories/ClientsRepository.swift
@@ -14,7 +14,7 @@ protocol ClientsRepository {
     func addClient(_ input: AddClientInput) async throws
 }
 
-struct DefualtClientsRepository: ClientsRepository {
+struct DefaultClientsRepository: ClientsRepository {
     let client: ClientServiceProtocol
 
     func fetchClients(sortedBy sortOption: ClientSortOption) async throws -> [ClientDTO] {


### PR DESCRIPTION
## Summary
- fix a typo in `ClientsRepository` implementation

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68524b484000832fb8998731d99ae698