### PR TITLE
Add async sheet helper for detail views

### DIFF
--- a/App/FreshWall/FreshWallApp/Clients/ClientDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientDetailView.swift
@@ -20,13 +20,11 @@ struct ClientDetailView: View {
     }
 
     /// Reloads the client data after editing.
-    private func reloadClient() {
-        Task {
-            guard let id = client.id else { return }
-            let updatedClients = await (try? clientService.fetchClients(sortedBy: .createdAtAscending)) ?? []
-            if let updated = updatedClients.first(where: { $0.id == id }) {
-                client = updated
-            }
+    private func reloadClient() async {
+        guard let id = client.id else { return }
+        let updatedClients = await (try? clientService.fetchClients(sortedBy: .createdAtAscending)) ?? []
+        if let updated = updatedClients.first(where: { $0.id == id }) {
+            client = updated
         }
     }
 
@@ -92,7 +90,7 @@ struct ClientDetailView: View {
                 Button("Edit") { showingEdit = true }
             }
         }
-        .sheet(isPresented: $showingEdit, onDismiss: reloadClient) {
+        .asyncSheet(isPresented: $showingEdit, onDismiss: reloadClient) {
             NavigationStack {
                 EditClientView(
                     viewModel: EditClientViewModel(client: client, service: clientService)

--- a/App/FreshWall/FreshWallApp/GenericViews/AsyncSheet.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/AsyncSheet.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+extension View {
+    /// Presents a sheet and performs asynchronous work when the sheet is dismissed.
+    /// - Parameters:
+    ///   - isPresented: Binding controlling the sheet's presentation.
+    ///   - onDismiss: Async closure executed when the sheet is dismissed.
+    ///   - content: View builder producing the sheet's content.
+    /// - Returns: A view that presents a sheet.
+    func asyncSheet<Content: View>(
+        isPresented: Binding<Bool>,
+        onDismiss: @escaping () async -> Void,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        sheet(isPresented: isPresented, onDismiss: {
+            Task { await onDismiss() }
+        }, content: content)
+    }
+}

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -15,13 +15,11 @@ struct IncidentDetailView: View {
     }
 
     /// Reloads the incident after editing.
-    private func reloadIncident() {
-        Task {
-            guard let id = incident.id else { return }
-            let updated = await (try? incidentService.fetchIncidents()) ?? []
-            if let match = updated.first(where: { $0.id == id }) {
-                incident = match
-            }
+    private func reloadIncident() async {
+        guard let id = incident.id else { return }
+        let updated = await (try? incidentService.fetchIncidents()) ?? []
+        if let match = updated.first(where: { $0.id == id }) {
+            incident = match
         }
     }
 
@@ -172,7 +170,7 @@ struct IncidentDetailView: View {
                 Button("Edit") { showingEdit = true }
             }
         }
-        .sheet(isPresented: $showingEdit, onDismiss: reloadIncident) {
+        .asyncSheet(isPresented: $showingEdit, onDismiss: reloadIncident) {
             NavigationStack {
                 EditIncidentView(
                     viewModel: EditIncidentViewModel(


### PR DESCRIPTION
## Summary
- add `asyncSheet` View extension
- update ClientDetailView and IncidentDetailView to use `asyncSheet`

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*
- `npm run lint` in `Firebase/functions` *(fails: biome not found)*
- `npm run build` in `Firebase/functions` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68525616c480832f9dd5747e33d381ed