### PR TITLE
Add image upload support for incidents

### DIFF
--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
@@ -43,8 +43,8 @@ final class AddIncidentViewModel {
         self.clientService = clientService
     }
 
-    /// Saves the new incident via the service.
-    func save() async throws {
+    /// Saves the new incident via the service along with photo data.
+    func save(beforeImages: [Data], afterImages: [Data]) async throws {
         let areaValue = Double(areaText) ?? 0
         let rateValue = Double(rateText)
         let input = AddIncidentInput(
@@ -59,7 +59,11 @@ final class AddIncidentViewModel {
             status: status,
             materialsUsed: materialsUsed.isEmpty ? nil : materialsUsed
         )
-        try await service.addIncident(input)
+        try await service.addIncident(
+            input,
+            beforeImages: beforeImages,
+            afterImages: afterImages
+        )
     }
 
     /// Loads available clients for the picker.

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
@@ -57,8 +57,8 @@ final class EditIncidentViewModel {
         materialsUsed = incident.materialsUsed ?? ""
     }
 
-    /// Saves the updated incident using the service.
-    func save() async throws {
+    /// Saves the updated incident using the service along with new photos.
+    func save(beforeImages: [Data], afterImages: [Data]) async throws {
         let input = UpdateIncidentInput(
             clientId: clientId.trimmingCharacters(in: .whitespaces),
             description: description,
@@ -71,7 +71,12 @@ final class EditIncidentViewModel {
             status: status,
             materialsUsed: materialsUsed.isEmpty ? nil : materialsUsed
         )
-        try await service.updateIncident(incidentId, with: input)
+        try await service.updateIncident(
+            incidentId,
+            with: input,
+            beforeImages: beforeImages,
+            afterImages: afterImages
+        )
     }
 
     /// Loads available clients for selection.

--- a/App/FreshWall/FreshWallApp/Services/StorageService.swift
+++ b/App/FreshWall/FreshWallApp/Services/StorageService.swift
@@ -1,0 +1,31 @@
+@preconcurrency import FirebaseStorage
+import Foundation
+
+/// Protocol defining operations for uploading binary data to Firebase Storage.
+protocol StorageServiceProtocol: Sendable {
+    /// Uploads data to the given storage path and returns a download URL string.
+    func uploadData(_ data: Data, to path: String) async throws -> String
+}
+
+/// Concrete storage service using `FirebaseStorage`.
+struct StorageService: StorageServiceProtocol {
+    private let storage: Storage
+
+    init(storage: Storage = .storage()) {
+        self.storage = storage
+    }
+
+    func uploadData(_ data: Data, to path: String) async throws -> String {
+        let ref = storage.reference(withPath: path)
+        _ = try await withCheckedThrowingContinuation { continuation in
+            ref.putData(data, metadata: nil) { _, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+        return try await ref.downloadURL().absoluteString
+    }
+}

--- a/App/FreshWall/FreshWallTests/EditIncidentViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/EditIncidentViewModelTests.swift
@@ -8,8 +8,17 @@ struct EditIncidentViewModelTests {
         var updateArgs: (String, UpdateIncidentInput)?
         func fetchIncidents() async throws -> [IncidentDTO] { [] }
         func addIncident(_: IncidentDTO) async throws {}
-        func addIncident(_: AddIncidentInput) async throws {}
-        func updateIncident(_ id: String, with input: UpdateIncidentInput) async throws {
+        func addIncident(
+            _ : AddIncidentInput,
+            beforeImages _: [Data],
+            afterImages _: [Data]
+        ) async throws {}
+        func updateIncident(
+            _ id: String,
+            with input: UpdateIncidentInput,
+            beforeImages _: [Data],
+            afterImages _: [Data]
+        ) async throws {
             updateArgs = (id, input)
         }
     }
@@ -77,7 +86,7 @@ struct EditIncidentViewModelTests {
         )
         let vm = EditIncidentViewModel(incident: incident, incidentService: incidentService, clientService: clientService)
         vm.description = "new"
-        try await vm.save()
+        try await vm.save(beforeImages: [], afterImages: [])
         #expect(incidentService.updateArgs?.0 == "1")
         #expect(incidentService.updateArgs?.1.description == "new")
     }

--- a/Firebase/storage.rules
+++ b/Firebase/storage.rules
@@ -5,8 +5,18 @@ rules_version = '2';
 //    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
-    match /{allPaths=**} {
-      allow read, write: if false;
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isInTeam(teamId) {
+      return exists(
+        /databases/(default)/documents/teams/$(teamId)/users/$(request.auth.uid)
+      );
+    }
+
+    match /teams/{teamId}/incidents/{allPaths=**} {
+      allow read, write: if isSignedIn() && isInTeam(teamId);
     }
   }
 }

--- a/Firebase/storage.rules
+++ b/Firebase/storage.rules
@@ -1,16 +1,14 @@
 rules_version = '2';
 
-// Craft rules based on data in your Firestore database
-// allow write: if firestore.get(
-//    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
+
     function isSignedIn() {
       return request.auth != null;
     }
 
     function isInTeam(teamId) {
-      return exists(
+      return firestore.exists(
         /databases/(default)/documents/teams/$(teamId)/users/$(request.auth.uid)
       );
     }


### PR DESCRIPTION
## Summary
- enable uploading photos through Firebase Storage
- store uploaded photo URLs when creating or editing incidents
- expose StorageService for uploading data
- allow image selection in Add/Edit Incident views
- update tests for new API
- permit Storage access in Firebase rules

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm run build` *(fails: module resolution errors)*
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525f20f460832f92b9b2a278b529ef