### PR TITLE
Add grouping to Incidents list

### DIFF
--- a/App/FreshWall/FreshWallApp/Incidents/IncidentGroupOption.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentGroupOption.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Options for grouping incidents in the list view.
+enum IncidentGroupOption: String, CaseIterable {
+    /// No grouping, show incidents in a flat list.
+    case none = "None"
+    /// Group incidents by their associated client.
+    case client = "Client"
+}

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
@@ -3,48 +3,100 @@ import SwiftUI
 
 /// A view displaying a list of incidents for the current team.
 struct IncidentsListView: View {
-    let service: IncidentServiceProtocol
+    let incidentService: IncidentServiceProtocol
+    let clientService: ClientServiceProtocol
     @Environment(RouterPath.self) private var routerPath
     @State private var viewModel: IncidentsListViewModel
+    @State private var clients: [ClientDTO] = []
+    @State private var groupOption: IncidentGroupOption = .none
+    @State private var showingGroupDialog = false
 
     /// Initializes the view with an incident service implementing `IncidentServiceProtocol`.
-    init(service: IncidentServiceProtocol) {
-        self.service = service
-        _viewModel = State(wrappedValue: IncidentsListViewModel(service: service))
+    init(incidentService: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
+        self.incidentService = incidentService
+        self.clientService = clientService
+        _viewModel = State(wrappedValue: IncidentsListViewModel(service: incidentService))
     }
 
     var body: some View {
-        GenericListView(
-            items: viewModel.incidents,
-            title: "Incidents",
-            destination: { incident in .incidentDetail(incident: incident) },
-            content: { incident in
-                IncidentListCell(incident: incident)
-            },
-            plusButtonAction: {
-                routerPath.push(.addIncident)
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                ForEach(viewModel.groupedIncidents(by: groupOption, clients: clients), id: \.title) { group in
+                    if let title = group.title, groupOption != .none {
+                        Text(title)
+                            .font(.headline)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal)
+                    }
+                    ForEach(group.incidents) { incident in
+                        NavigationLink(value: RouterDestination.incidentDetail(incident: incident)) {
+                            IncidentListCell(incident: incident)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.horizontal)
+                    }
+                }
             }
-        )
+        }
+        .scrollIndicators(.hidden)
+        .navigationTitle("Incidents")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showingGroupDialog = true
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    routerPath.push(.addIncident)
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .confirmationDialog("Group By", isPresented: $showingGroupDialog) {
+            ForEach(IncidentGroupOption.allCases, id: \.self) { option in
+                Button(option.rawValue) { groupOption = option }
+            }
+        }
         .task {
             await viewModel.loadIncidents()
+            clients = await (try? clientService.fetchClients(sortedBy: .createdAtAscending)) ?? []
         }
     }
 }
 
 #Preview {
-    let userService = UserService()
-    let firestore = Firestore.firestore()
-    let service = IncidentService(
-        firestore: firestore,
-        session: .init(
-            userId: "",
-            displayName: "",
-            teamId: ""
-        )
-    )
+    @MainActor class PreviewIncidentService: IncidentServiceProtocol {
+        func fetchIncidents() async throws -> [IncidentDTO] { [] }
+        func addIncident(_: IncidentDTO) async throws {}
+        func addIncident(_ : AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
+        func updateIncident(_ : String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
+    }
+
+    @MainActor class PreviewClientService: ClientServiceProtocol {
+        func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] {
+            [ClientDTO(
+                id: "client1",
+                name: "Sample Client",
+                notes: nil,
+                isDeleted: false,
+                deletedAt: nil,
+                createdAt: .init(),
+                lastIncidentAt: .init()
+            )]
+        }
+        func addClient(_: AddClientInput) async throws {}
+        func updateClient(_: String, with _: UpdateClientInput) async throws {}
+    }
+
+    let incidentService = PreviewIncidentService()
+    let clientService = PreviewClientService()
     FreshWallPreview {
         NavigationStack {
-            IncidentsListView(service: service)
+            IncidentsListView(incidentService: incidentService, clientService: clientService)
         }
     }
 }

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
@@ -17,4 +17,31 @@ final class IncidentsListViewModel {
     func loadIncidents() async {
         incidents = await (try? service.fetchIncidents()) ?? []
     }
+
+    /// Returns incidents grouped according to the provided option and clients.
+    /// - Parameters:
+    ///   - option: How incidents should be grouped.
+    ///   - clients: All clients used to resolve names when grouping by client.
+    /// - Returns: An array of tuples where the first value is an optional group
+    ///   title and the second is the incidents for that group.
+    func groupedIncidents(
+        by option: IncidentGroupOption,
+        clients: [ClientDTO]
+    ) -> [(title: String?, incidents: [IncidentDTO])] {
+        switch option {
+        case .none:
+            return [(nil, incidents)]
+        case .client:
+            let groups = Dictionary(grouping: incidents) { incident in
+                incident.clientRef.documentID
+            }
+            return groups.map { key, value in
+                let name = clients.first { $0.id == key }?.name ?? "Unknown"
+                return (title: name, incidents: value)
+            }
+            .sorted { lhs, rhs in
+                (lhs.title ?? "") < (rhs.title ?? "")
+            }
+        }
+    }
 }

--- a/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
+++ b/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
@@ -58,7 +58,10 @@ extension View {
                     clientService: clientService
                 )
             case .incidentsList:
-                IncidentsListView(service: incidentService)
+                IncidentsListView(
+                    incidentService: incidentService,
+                    clientService: clientService
+                )
             case .addIncident:
                 AddIncidentView(
                     viewModel: AddIncidentViewModel(

--- a/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
@@ -1,0 +1,63 @@
+import FirebaseFirestore
+@testable import FreshWall
+import Testing
+
+@MainActor
+struct IncidentsListViewModelTests {
+    final class MockService: IncidentServiceProtocol {
+        func fetchIncidents() async throws -> [IncidentDTO] { [] }
+        func addIncident(_: IncidentDTO) async throws {}
+        func addIncident(_ : AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
+        func updateIncident(_ : String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
+    }
+
+    @Test func groupingByClient() {
+        let service = MockService()
+        let vm = IncidentsListViewModel(service: service)
+        let clientRefA = Firestore.firestore().document("teams/t/clients/a")
+        let clientRefB = Firestore.firestore().document("teams/t/clients/b")
+        let baseIncident = IncidentDTO(
+            id: "1",
+            clientRef: clientRefA,
+            workerRefs: [],
+            description: "d",
+            area: 1,
+            createdAt: Timestamp(date: .init()),
+            startTime: Timestamp(date: .init()),
+            endTime: Timestamp(date: .init()),
+            beforePhotoUrls: [],
+            afterPhotoUrls: [],
+            createdBy: Firestore.firestore().document("teams/t/users/u"),
+            lastModifiedBy: nil,
+            lastModifiedAt: nil,
+            billable: false,
+            rate: nil,
+            projectName: nil,
+            status: "open",
+            materialsUsed: nil
+        )
+        var second = baseIncident
+        second.id = "2"
+        second.clientRef = clientRefB
+        vm.incidents = [baseIncident, second]
+
+        let clients = [
+            ClientDTO(id: "a", name: "A", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
+            ClientDTO(id: "b", name: "B", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init())
+        ]
+
+        let grouped = vm.groupedIncidents(by: .client, clients: clients)
+        #expect(grouped.count == 2)
+        #expect(grouped[0].title == "A")
+        #expect(grouped[1].title == "B")
+    }
+
+    @Test func groupingNone() {
+        let service = MockService()
+        let vm = IncidentsListViewModel(service: service)
+        vm.incidents = []
+        let groups = vm.groupedIncidents(by: .none, clients: [])
+        #expect(groups.count == 1)
+        #expect(groups.first?.incidents.isEmpty == true)
+    }
+}


### PR DESCRIPTION
## Summary
- add `IncidentGroupOption` for grouping modes
- implement grouped incident logic in `IncidentsListViewModel`
- show grouping button in `IncidentsListView` with `Client` option
- update router to pass `clientService`
- test grouping logic

## Testing
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ae46855c832fb375042bc5b4e9df