### PR TITLE
Move incident list state to view model

### DIFF
--- a/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
+++ b/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
@@ -59,8 +59,10 @@ extension View {
                 )
             case .incidentsList:
                 IncidentsListView(
-                    incidentService: incidentService,
-                    clientService: clientService
+                    viewModel: IncidentsListViewModel(
+                        incidentService: incidentService,
+                        clientService: clientService
+                    )
                 )
             case .addIncident:
                 AddIncidentView(

--- a/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
@@ -10,10 +10,16 @@ struct IncidentsListViewModelTests {
         func addIncident(_ : AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
         func updateIncident(_ : String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
     }
+    final class MockClientService: ClientServiceProtocol {
+        func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] { [] }
+        func addClient(_: AddClientInput) async throws {}
+        func updateClient(_: String, with _: UpdateClientInput) async throws {}
+    }
 
     @Test func groupingByClient() {
         let service = MockService()
-        let vm = IncidentsListViewModel(service: service)
+        let clientService = MockClientService()
+        let vm = IncidentsListViewModel(incidentService: service, clientService: clientService)
         let clientRefA = Firestore.firestore().document("teams/t/clients/a")
         let clientRefB = Firestore.firestore().document("teams/t/clients/b")
         let baseIncident = IncidentDTO(
@@ -40,13 +46,13 @@ struct IncidentsListViewModelTests {
         second.id = "2"
         second.clientRef = clientRefB
         vm.incidents = [baseIncident, second]
-
-        let clients = [
+        vm.groupOption = .client
+        vm.clients = [
             ClientDTO(id: "a", name: "A", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
             ClientDTO(id: "b", name: "B", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init())
         ]
 
-        let grouped = vm.groupedIncidents(by: .client, clients: clients)
+        let grouped = vm.groupedIncidents()
         #expect(grouped.count == 2)
         #expect(grouped[0].title == "A")
         #expect(grouped[1].title == "B")
@@ -54,9 +60,12 @@ struct IncidentsListViewModelTests {
 
     @Test func groupingNone() {
         let service = MockService()
-        let vm = IncidentsListViewModel(service: service)
+        let clientService = MockClientService()
+        let vm = IncidentsListViewModel(incidentService: service, clientService: clientService)
+        vm.groupOption = .none
         vm.incidents = []
-        let groups = vm.groupedIncidents(by: .none, clients: [])
+        vm.clients = []
+        let groups = vm.groupedIncidents()
         #expect(groups.count == 1)
         #expect(groups.first?.incidents.isEmpty == true)
     }


### PR DESCRIPTION
## Summary
- store incident grouping state in `IncidentsListViewModel`
- update `IncidentsListView` to use new properties
- adjust unit tests for new view model API
- instantiate `IncidentsListView` with its view model instead of injecting services

## Testing
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b9d89520832f98907bd50ec77d5a