### PR TITLE
Enable group context menu

### DIFF
--- a/App/FreshWall/FreshWallApp/GenericViews/GenericGroupableListView.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/GenericGroupableListView.swift
@@ -56,12 +56,17 @@ struct GenericGroupableListView<Item: Identifiable, GroupOption: CaseIterable & 
         .navigationTitle(title)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Image(systemName: "line.3.horizontal.decrease.circle")
-                    .contextMenu {
-                        ForEach(Array(GroupOption.allCases), id: \.self) { option in
-                            Button(option.rawValue) { groupOption = option }
+                Menu {
+                    ForEach(Array(GroupOption.allCases), id: \.self) { option in
+                        Button {
+                            groupOption = option
+                        } label: {
+                            Label(option.rawValue, systemImage: option == groupOption ? "checkmark" : "")
                         }
                     }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button { plusButtonAction() } label: { Image(systemName: "plus") }

--- a/App/FreshWall/FreshWallApp/GenericViews/GenericGroupableListView.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/GenericGroupableListView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// A generic view for displaying items grouped into sections with a context menu for selecting a grouping option.
+struct GenericGroupableListView<Item: Identifiable, GroupOption: CaseIterable & Hashable & RawRepresentable, Content: View>: View where GroupOption.RawValue == String {
+    /// Groups of items along with optional section titles.
+    var groups: [(title: String?, items: [Item])]
+    /// Title used in the navigation bar.
+    var title: String
+    /// Currently selected grouping option.
+    @Binding var groupOption: GroupOption
+    /// Produces a navigation destination for a given item.
+    var destination: (Item) -> RouterDestination
+    /// Creates the content view for a given item.
+    var content: (Item) -> Content
+
+    let plusButtonAction: @MainActor () -> Void
+
+    init(
+        groups: [(title: String?, items: [Item])],
+        title: String,
+        groupOption: Binding<GroupOption>,
+        destination: @escaping (Item) -> RouterDestination,
+        content: @escaping (Item) -> Content,
+        plusButtonAction: @escaping @MainActor () -> Void
+    ) {
+        self.groups = groups
+        self.title = title
+        _groupOption = groupOption
+        self.destination = destination
+        self.content = content
+        self.plusButtonAction = plusButtonAction
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                ForEach(groups.indices, id: \.self) { index in
+                    let group = groups[index]
+                    if let title = group.title {
+                        Text(title)
+                            .font(.headline)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal)
+                    }
+                    ForEach(group.items) { item in
+                        NavigationLink(value: destination(item)) {
+                            content(item)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.horizontal)
+                    }
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+        .navigationTitle(title)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Image(systemName: "line.3.horizontal.decrease.circle")
+                    .contextMenu {
+                        ForEach(Array(GroupOption.allCases), id: \.self) { option in
+                            Button(option.rawValue) { groupOption = option }
+                        }
+                    }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button { plusButtonAction() } label: { Image(systemName: "plus") }
+            }
+        }
+    }
+}

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
@@ -12,48 +12,18 @@ struct IncidentsListView: View {
     }
 
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: 16) {
-                ForEach(viewModel.groupedIncidents(), id: \.title) { group in
-                    if let title = group.title, viewModel.groupOption != .none {
-                        Text(title)
-                            .font(.headline)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal)
-                    }
-                    ForEach(group.incidents) { incident in
-                        NavigationLink(value: RouterDestination.incidentDetail(incident: incident)) {
-                            IncidentListCell(incident: incident)
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.horizontal)
-                    }
-                }
+        GenericGroupableListView(
+            groups: viewModel.groupedIncidents(),
+            title: "Incidents",
+            groupOption: $viewModel.groupOption,
+            destination: { incident in .incidentDetail(incident: incident) },
+            content: { incident in
+                IncidentListCell(incident: incident)
+            },
+            plusButtonAction: {
+                routerPath.push(.addIncident)
             }
-        }
-        .scrollIndicators(.hidden)
-        .navigationTitle("Incidents")
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    viewModel.showingGroupDialog = true
-                } label: {
-                    Image(systemName: "line.3.horizontal.decrease.circle")
-                }
-            }
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    routerPath.push(.addIncident)
-                } label: {
-                    Image(systemName: "plus")
-                }
-            }
-        }
-        .confirmationDialog("Group By", isPresented: $viewModel.showingGroupDialog) {
-            ForEach(IncidentGroupOption.allCases, id: \.self) { option in
-                Button(option.rawValue) { viewModel.groupOption = option }
-            }
-        }
+        )
         .task {
             await viewModel.loadIncidents()
             await viewModel.loadClients()

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
@@ -35,7 +35,7 @@ final class IncidentsListViewModel {
         clients = await (try? clientService.fetchClients(sortedBy: .createdAtAscending)) ?? []
     }
 
-    func groupedIncidents() -> [(title: String?, incidents: [IncidentDTO])] {
+    func groupedIncidents() -> [(title: String?, items: [IncidentDTO])] {
         switch groupOption {
         case .none:
             return [(nil, incidents)]
@@ -45,7 +45,7 @@ final class IncidentsListViewModel {
             }
             return groups.map { key, value in
                 let name = clients.first { $0.id == key }?.name ?? "Unknown"
-                return (title: name, incidents: value)
+                return (title: name, items: value)
             }
             .sorted { lhs, rhs in
                 (lhs.title ?? "") < (rhs.title ?? "")

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
@@ -10,8 +10,6 @@ final class IncidentsListViewModel {
     var clients: [ClientDTO] = []
     /// Selected grouping option for incidents.
     var groupOption: IncidentGroupOption = .none
-    /// Indicates whether the grouping dialog is presented.
-    var showingGroupDialog = false
 
     private let service: IncidentServiceProtocol
     private let clientService: ClientServiceProtocol

--- a/App/FreshWall/FreshWallTests/GenericGroupableListViewTests.swift
+++ b/App/FreshWall/FreshWallTests/GenericGroupableListViewTests.swift
@@ -1,0 +1,20 @@
+@testable import FreshWall
+import SwiftUI
+import Testing
+
+struct GenericGroupableListViewTests {
+    struct Item: Identifiable { let id: Int }
+    enum Option: String, CaseIterable { case none }
+
+    @Test func initDoesNotCrash() {
+        let groups = [(title: "Title", items: [Item(id: 1)])]
+        _ = GenericGroupableListView(
+            groups: groups,
+            title: "Test",
+            groupOption: .constant(.none),
+            destination: { _ in .clientsList },
+            content: { _ in EmptyView() },
+            plusButtonAction: {}
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add `GenericGroupableListView` for grouped lists with a context menu
- update `IncidentsListView` to use the generic view
- simplify `IncidentsListViewModel` (remove unused dialog flag)
- add a basic test for `GenericGroupableListView`

## Testing
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853bd6cc99c832f93c430883f1e2ab9