### PR TITLE
Rename projectName to projectTitle

### DIFF
--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
@@ -21,52 +21,52 @@ struct AddIncidentView: View {
     var body: some View {
         Form {
             Section(header: Text("Client")) {
-                Picker("Select Client", selection: $viewModel.clientId) {
+                Picker("Select Client", selection: $viewModel.input.clientId) {
                     Text("Add New Client...").tag(addNewTag)
                     ForEach(viewModel.validClients, id: \.id) { item in
                         Text(item.name).tag(item.id)
                     }
                 }
                 .pickerStyle(.menu)
-                .onChange(of: viewModel.clientId) { _, newValue in
+                .onChange(of: viewModel.input.clientId) { _, newValue in
                     if newValue == addNewTag {
                         routerPath.push(.addClient)
-                        viewModel.clientId = ""
+                        viewModel.input.clientId = ""
                     }
                 }
             }
-            Section(header: Text("Description")) {
-                TextEditor(text: $viewModel.description)
+            Section(header: Text("Project Title")) {
+                TextField("Project Title", text: $viewModel.input.projectTitle)
+            }
+            Section(header: Text("Notes")) {
+                TextEditor(text: $viewModel.input.description)
                     .frame(minHeight: 100)
             }
             Section(header: Text("Area (sq ft)")) {
-                TextField("Area", text: $viewModel.areaText)
+                TextField("Area", text: $viewModel.input.areaText)
                     .keyboardType(.decimalPad)
             }
             Section(header: Text("Timeframe")) {
                 DatePicker(
                     "Start Time",
-                    selection: $viewModel.startTime,
+                    selection: $viewModel.input.startTime,
                     displayedComponents: [.date, .hourAndMinute]
                 )
                 DatePicker(
                     "End Time",
-                    selection: $viewModel.endTime,
+                    selection: $viewModel.input.endTime,
                     displayedComponents: [.date, .hourAndMinute]
                 )
             }
             Section {
-                Toggle("Billable", isOn: $viewModel.billable)
-                if viewModel.billable {
-                    TextField("Rate", text: $viewModel.rateText)
+                Toggle("Billable", isOn: $viewModel.input.billable)
+                if viewModel.input.billable {
+                    TextField("Rate", text: $viewModel.input.rateText)
                         .keyboardType(.decimalPad)
                 }
             }
-            Section(header: Text("Project Name")) {
-                TextField("Project Name", text: $viewModel.projectName)
-            }
             Section(header: Text("Status")) {
-                Picker("Status", selection: $viewModel.status) {
+                Picker("Status", selection: $viewModel.input.status) {
                     ForEach(viewModel.statusOptions, id: \.self) { option in
                         Text(option.capitalized).tag(option)
                     }
@@ -74,7 +74,7 @@ struct AddIncidentView: View {
                 .pickerStyle(.segmented)
             }
             Section(header: Text("Materials Used")) {
-                TextEditor(text: $viewModel.materialsUsed)
+                TextEditor(text: $viewModel.input.materialsUsed)
                     .frame(minHeight: 80)
             }
             if !beforeImages.isEmpty {

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
@@ -5,26 +5,32 @@ import Observation
 @MainActor
 @Observable
 final class AddIncidentViewModel {
-    /// Client document ID or special tag for add-new.
-    var clientId: String = ""
-    /// Description of the incident.
-    var description: String = ""
-    /// Area affected (as text input).
-    var areaText: String = ""
-    /// Start time of incident.
-    var startTime: Date = .init()
-    /// End time of incident.
-    var endTime: Date = .init()
-    /// Whether the incident is billable.
-    var billable: Bool = false
-    /// Billing rate (as text input).
-    var rateText: String = ""
-    /// Optional project name.
-    var projectName: String = ""
-    /// Status of the incident.
-    var status: String = "open"
-    /// Materials used description.
-    var materialsUsed: String = ""
+    /// Container for all editable incident fields.
+    struct Input {
+        /// Title of the project.
+        var projectTitle: String = ""
+        /// Selected client document ID or tag for add-new.
+        var clientId: String = ""
+        /// Notes describing the incident.
+        var description: String = ""
+        /// Area affected as free-form text.
+        var areaText: String = ""
+        /// Start time of incident.
+        var startTime: Date = .init()
+        /// End time of incident.
+        var endTime: Date = .init()
+        /// Whether the incident is billable.
+        var billable: Bool = false
+        /// Billing rate as text.
+        var rateText: String = ""
+        /// Status of the incident.
+        var status: String = "open"
+        /// Materials used description.
+        var materialsUsed: String = ""
+    }
+
+    /// Current input being edited.
+    var input = Input()
     /// Available status options.
     let statusOptions = ["open", "in_progress", "completed"]
     /// Loaded clients for selection.
@@ -32,10 +38,11 @@ final class AddIncidentViewModel {
     private let clientService: ClientServiceProtocol
     private let service: IncidentServiceProtocol
 
-    /// Validation: requires a clientId and description.
+    /// Validation: requires a clientId, description, and project title.
     var isValid: Bool {
-        !clientId.trimmingCharacters(in: .whitespaces).isEmpty &&
-            !description.trimmingCharacters(in: .whitespaces).isEmpty
+        !input.clientId.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !input.description.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !input.projectTitle.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     init(service: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
@@ -45,19 +52,19 @@ final class AddIncidentViewModel {
 
     /// Saves the new incident via the service along with photo data.
     func save(beforeImages: [Data], afterImages: [Data]) async throws {
-        let areaValue = Double(areaText) ?? 0
-        let rateValue = Double(rateText)
+        let areaValue = Double(input.areaText) ?? 0
+        let rateValue = Double(input.rateText)
         let input = AddIncidentInput(
-            clientId: clientId.trimmingCharacters(in: .whitespaces),
-            description: description,
+            clientId: self.input.clientId.trimmingCharacters(in: .whitespaces),
+            description: self.input.description,
             area: areaValue,
-            startTime: startTime,
-            endTime: endTime,
-            billable: billable,
+            startTime: self.input.startTime,
+            endTime: self.input.endTime,
+            billable: self.input.billable,
             rate: rateValue,
-            projectName: projectName.isEmpty ? nil : projectName,
-            status: status,
-            materialsUsed: materialsUsed.isEmpty ? nil : materialsUsed
+            projectTitle: self.input.projectTitle,
+            status: self.input.status,
+            materialsUsed: self.input.materialsUsed.isEmpty ? nil : self.input.materialsUsed
         )
         try await service.addIncident(
             input,

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
@@ -56,8 +56,8 @@ struct EditIncidentView: View {
                         .keyboardType(.decimalPad)
                 }
             }
-            Section("Project Name") {
-                TextField("Project Name", text: $viewModel.projectName)
+            Section("Project Title") {
+                TextField("Project Title", text: $viewModel.projectTitle)
             }
             Section("Status") {
                 Picker("Status", selection: $viewModel.status) {
@@ -213,7 +213,7 @@ private class PreviewIncidentService: IncidentServiceProtocol {
         lastModifiedAt: nil,
         billable: false,
         rate: nil,
-        projectName: nil,
+        projectTitle: "",
         status: "open",
         materialsUsed: nil
     )

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
@@ -199,6 +199,7 @@ private class PreviewIncidentService: IncidentServiceProtocol {
 #Preview {
     let incident = IncidentDTO(
         id: "inc1",
+        projectTitle: "",
         clientRef: Firestore.firestore().document("teams/t/clients/client1"),
         workerRefs: [],
         description: "Some incident",
@@ -213,7 +214,6 @@ private class PreviewIncidentService: IncidentServiceProtocol {
         lastModifiedAt: nil,
         billable: false,
         rate: nil,
-        projectTitle: "",
         status: "open",
         materialsUsed: nil
     )

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
@@ -9,7 +9,7 @@ import Observation
 final class EditIncidentViewModel {
     /// Selected client document ID.
     var clientId: String
-    /// Description text.
+    /// Notes text.
     var description: String
     /// Area affected input as text.
     var areaText: String
@@ -21,8 +21,8 @@ final class EditIncidentViewModel {
     var billable: Bool
     /// Billing rate input as text.
     var rateText: String
-    /// Optional project name.
-    var projectName: String
+    /// Project title.
+    var projectTitle: String
     /// Incident status string.
     var status: String
     /// Materials used description.
@@ -44,10 +44,11 @@ final class EditIncidentViewModel {
     private let service: IncidentServiceProtocol
     private let clientService: ClientServiceProtocol
 
-    /// Validation: requires a client and description.
+    /// Validation: requires a client, description, and project title.
     var isValid: Bool {
         !clientId.trimmingCharacters(in: .whitespaces).isEmpty &&
-            !description.trimmingCharacters(in: .whitespaces).isEmpty
+            !description.trimmingCharacters(in: .whitespaces).isEmpty &&
+            !projectTitle.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     init(incident: IncidentDTO, incidentService: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
@@ -61,7 +62,7 @@ final class EditIncidentViewModel {
         endTime = incident.endTime.dateValue()
         billable = incident.billable
         rateText = incident.rate.map { String($0) } ?? ""
-        projectName = incident.projectName ?? ""
+        projectTitle = incident.projectTitle
         status = incident.status
         materialsUsed = incident.materialsUsed ?? ""
     }
@@ -76,7 +77,7 @@ final class EditIncidentViewModel {
             endTime: endTime,
             billable: billable,
             rate: Double(rateText),
-            projectName: projectName.isEmpty ? nil : projectName,
+            projectTitle: projectTitle,
             status: status,
             materialsUsed: materialsUsed.isEmpty ? nil : materialsUsed
         )

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -35,18 +35,14 @@ struct IncidentDetailView: View {
     var body: some View {
         List {
             Section("Overview") {
-                Text(incident.description)
+                Text(incident.projectTitle)
+                if !incident.description.trimmingCharacters(in: .whitespaces).isEmpty {
+                    Text(incident.description)
+                }
                 HStack {
                     Text("Status")
                     Spacer()
                     Text(incident.status.capitalized)
-                }
-                if let project = incident.projectName {
-                    HStack {
-                        Text("Project")
-                        Spacer()
-                        Text(project)
-                    }
                 }
                 HStack {
                     Text("Area")
@@ -211,7 +207,7 @@ struct IncidentDetailView: View {
 //        lastModifiedAt: nil,
 //        billable: true,
 //        rate: 75.0,
-//        projectName: "Front Wall Project",
+//        projectTitle: "Front Wall Project",
 //        status: "completed",
 //        materialsUsed: "Paint, brushes"
 //    )

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentListCell.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentListCell.swift
@@ -7,7 +7,7 @@ struct IncidentListCell: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(incident.description)
+            Text(incident.projectTitle)
                 .font(.headline)
             HStack(spacing: 12) {
                 Text(incident.status.capitalized)

--- a/App/FreshWall/FreshWallApp/Models/IncidentDTO.swift
+++ b/App/FreshWall/FreshWallApp/Models/IncidentDTO.swift
@@ -5,11 +5,13 @@ import Foundation
 struct IncidentDTO: Codable, Identifiable, Sendable, Hashable {
     /// Firestore-generated document identifier for the incident.
     @DocumentID var id: String?
+    /// Title describing the project for this incident.
+    var projectTitle: String
     /// Reference to the client document associated with this incident.
     var clientRef: DocumentReference
     /// References to worker user documents involved in this incident.
     var workerRefs: [DocumentReference]
-    /// Description of the incident.
+    /// Notes describing the incident.
     var description: String
     /// Area affected by the incident.
     var area: Double
@@ -33,8 +35,6 @@ struct IncidentDTO: Codable, Identifiable, Sendable, Hashable {
     var billable: Bool
     /// Optional billing rate applied to this incident.
     var rate: Double?
-    /// Optional project name associated with this incident.
-    var projectName: String?
     /// Current status of the incident (e.g. "open", "in_progress", "completed").
     var status: String
     /// Materials used during the incident work (optional details).

--- a/App/FreshWall/FreshWallApp/Services/IncidentService.swift
+++ b/App/FreshWall/FreshWallApp/Services/IncidentService.swift
@@ -92,6 +92,7 @@ struct IncidentService: IncidentServiceProtocol {
 
         let newIncident = IncidentDTO(
             id: newDoc.documentID,
+            projectTitle: input.projectTitle,
             clientRef: clientRef,
             workerRefs: [],
             description: input.description,
@@ -106,7 +107,6 @@ struct IncidentService: IncidentServiceProtocol {
             lastModifiedAt: nil,
             billable: input.billable,
             rate: input.rate,
-            projectTitle: input.projectTitle,
             status: input.status,
             materialsUsed: input.materialsUsed
         )

--- a/App/FreshWall/FreshWallApp/Services/IncidentService.swift
+++ b/App/FreshWall/FreshWallApp/Services/IncidentService.swift
@@ -106,7 +106,7 @@ struct IncidentService: IncidentServiceProtocol {
             lastModifiedAt: nil,
             billable: input.billable,
             rate: input.rate,
-            projectName: input.projectName,
+            projectTitle: input.projectTitle,
             status: input.status,
             materialsUsed: input.materialsUsed
         )
@@ -146,11 +146,7 @@ struct IncidentService: IncidentServiceProtocol {
             data["rate"] = FieldValue.delete()
         }
 
-        if let projectName = input.projectName {
-            data["projectName"] = projectName
-        } else {
-            data["projectName"] = FieldValue.delete()
-        }
+        data["projectTitle"] = input.projectTitle
 
         if let materialsUsed = input.materialsUsed {
             data["materialsUsed"] = materialsUsed

--- a/App/FreshWall/FreshWallApp/Services/Input Models/AddIncidentInput.swift
+++ b/App/FreshWall/FreshWallApp/Services/Input Models/AddIncidentInput.swift
@@ -16,8 +16,8 @@ struct AddIncidentInput: Sendable {
     let billable: Bool
     /// Optional rate for billing.
     let rate: Double?
-    /// Optional project name.
-    let projectName: String?
+    /// Title of the project.
+    let projectTitle: String
     /// Status string (e.g. "open", "completed").
     let status: String
     /// Optional materials used description.

--- a/App/FreshWall/FreshWallApp/Services/Input Models/UpdateIncidentInput.swift
+++ b/App/FreshWall/FreshWallApp/Services/Input Models/UpdateIncidentInput.swift
@@ -17,8 +17,8 @@ struct UpdateIncidentInput: Sendable {
     let billable: Bool
     /// Optional billing rate for the incident.
     let rate: Double?
-    /// Optional project name.
-    let projectName: String?
+    /// Title of the project.
+    let projectTitle: String
     /// Status of the incident (e.g. "open").
     let status: String
     /// Optional materials used description.

--- a/App/FreshWall/FreshWallTests/ClientsListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/ClientsListViewModelTests.swift
@@ -57,7 +57,7 @@ struct ClientsListViewModelTests {
             lastModifiedAt: nil,
             billable: false,
             rate: nil,
-            projectName: nil,
+            projectTitle: "",
             status: "open",
             materialsUsed: nil
         )

--- a/App/FreshWall/FreshWallTests/EditIncidentViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/EditIncidentViewModelTests.swift
@@ -48,16 +48,18 @@ struct EditIncidentViewModelTests {
             lastModifiedAt: nil,
             billable: false,
             rate: nil,
-            projectName: nil,
+            projectTitle: "",
             status: "open",
             materialsUsed: nil
         )
         let vm = EditIncidentViewModel(incident: incident, incidentService: incidentService, clientService: clientService)
         vm.description = ""
         vm.clientId = ""
+        vm.projectTitle = ""
         #expect(vm.isValid == false)
         vm.clientId = "c"
         vm.description = "test"
+        vm.projectTitle = "Title"
         #expect(vm.isValid == true)
     }
 
@@ -80,7 +82,7 @@ struct EditIncidentViewModelTests {
             lastModifiedAt: nil,
             billable: false,
             rate: nil,
-            projectName: nil,
+            projectTitle: "",
             status: "open",
             materialsUsed: nil
         )

--- a/App/FreshWall/FreshWallTests/IncidentServiceCompositionTests.swift
+++ b/App/FreshWall/FreshWallTests/IncidentServiceCompositionTests.swift
@@ -52,7 +52,7 @@ struct IncidentServiceCompositionTests {
             session: session
         )
         let input = AddIncidentInput(
-            clientId: "c", description: "d", area: 1, startTime: .init(), endTime: .init(), billable: false, rate: nil, projectName: nil, status: "open", materialsUsed: nil
+            clientId: "c", description: "d", area: 1, startTime: .init(), endTime: .init(), billable: false, rate: nil, projectTitle: "", status: "open", materialsUsed: nil
         )
         try await service.addIncident(input, beforeImages: [Data()], afterImages: [])
         let added = await model.added

--- a/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
@@ -39,7 +39,7 @@ struct IncidentsListViewModelTests {
             lastModifiedAt: nil,
             billable: false,
             rate: nil,
-            projectName: nil,
+            projectTitle: "",
             status: "open",
             materialsUsed: nil
         )
@@ -95,7 +95,7 @@ struct IncidentsListViewModelTests {
             lastModifiedAt: nil,
             billable: false,
             rate: nil,
-            projectName: nil,
+            projectTitle: "",
             status: "open",
             materialsUsed: nil
         )
@@ -141,7 +141,7 @@ struct IncidentsListViewModelTests {
             lastModifiedAt: nil,
             billable: false,
             rate: nil,
-            projectName: nil,
+            projectTitle: "",
             status: "open",
             materialsUsed: nil
         )
@@ -180,7 +180,7 @@ struct IncidentsListViewModelTests {
             lastModifiedAt: nil,
             billable: false,
             rate: nil,
-            projectName: nil,
+            projectTitle: "",
             status: "open",
             materialsUsed: nil
         )


### PR DESCRIPTION
## Summary
- rename IncidentDTO `projectName` -> `projectTitle`
- update AddIncident and EditIncident view models and views
- validate project title in add/edit view models
- update IncidentService to persist `projectTitle`
- refactor AddIncidentViewModel to use an `Input` struct
- adjust tests for new property

## Testing
- `swift test -list-tests` *(fails: Missing value for '-s <specifier>')*
- `npm run lint` *(fails: biome not found)*
- `npm run build` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685767d0b404832fb156f412b85b0385