### PR TITLE
Replace DTOs with domain models in UI

### DIFF
--- a/App/FreshWall/FreshWallApp/Clients/AddClientView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/AddClientView.swift
@@ -45,7 +45,7 @@ struct AddClientView: View {
 /// Dummy implementation of `ClientServiceProtocol` for previews.
 @MainActor
 private class PreviewClientService: ClientServiceProtocol {
-    func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] { [] }
+    func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] { [] }
     func addClient(_: AddClientInput) async throws {}
     func updateClient(_: String, with _: UpdateClientInput) async throws {}
 }

--- a/App/FreshWall/FreshWallApp/Clients/ClientDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientDetailView.swift
@@ -3,14 +3,14 @@ import SwiftUI
 
 /// A view displaying detailed information for a specific client.
 struct ClientDetailView: View {
-    @State private var client: ClientDTO
+    @State private var client: Client
     let incidentService: IncidentServiceProtocol
     let clientService: ClientServiceProtocol
     @Environment(RouterPath.self) private var routerPath
-    @State private var incidents: [IncidentDTO] = []
+    @State private var incidents: [Incident] = []
     @State private var showingEdit = false
 
-    init(client: ClientDTO,
+    init(client: Client,
          incidentService: IncidentServiceProtocol,
          clientService: ClientServiceProtocol)
     {
@@ -102,7 +102,7 @@ struct ClientDetailView: View {
 
 //
 // #Preview {
-//    let sampleClient = ClientDTO(
+//    let sampleClient = Client(
 //        id: "client123",
 //        name: "Test Client",
 //        notes: "Sample notes",

--- a/App/FreshWall/FreshWallApp/Clients/ClientListCell.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientListCell.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// A cell view displaying summary information for a client.
 struct ClientListCell: View {
-    let client: ClientDTO
+    let client: Client
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/App/FreshWall/FreshWallApp/Clients/ClientsListView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientsListView.swift
@@ -54,7 +54,7 @@ struct ClientsListView: View {
                 viewModel.isAscending = true
             }
         } label: {
-            let arrow = viewModel.sortField == .alphabetical ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : ""
+            let arrow = viewModel.sortField == .alphabetical ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : nil
             Label("Alphabetical", systemImage: arrow)
         }
 
@@ -66,7 +66,7 @@ struct ClientsListView: View {
                 viewModel.isAscending = false
             }
         } label: {
-            let arrow = viewModel.sortField == .incidentDate ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : ""
+            let arrow = viewModel.sortField == .incidentDate ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : nil
             Label("By Incident Date", systemImage: arrow)
         }
     }

--- a/App/FreshWall/FreshWallApp/Clients/ClientsListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientsListViewModel.swift
@@ -6,9 +6,9 @@ import Foundation
 @Observable
 final class ClientsListViewModel {
     /// Clients fetched from the client service.
-    var clients: [ClientDTO] = []
+    var clients: [Client] = []
     /// Incidents fetched from the incident service.
-    var incidents: [IncidentDTO] = []
+    var incidents: [Incident] = []
     /// Field used when sorting clients.
     var sortField: ClientSortField = .incidentDate
     /// Indicates whether sorting is ascending.
@@ -34,7 +34,7 @@ final class ClientsListViewModel {
     }
 
     /// Returns clients sorted using the current sort field and direction.
-    func sortedClients() -> [ClientDTO] {
+    func sortedClients() -> [Client] {
         switch sortField {
         case .alphabetical:
             return clients.sorted { lhs, rhs in
@@ -58,7 +58,7 @@ final class ClientsListViewModel {
     }
 
     /// Returns the latest incident date for a client or distantPast if none.
-    private func lastIncidentDate(for client: ClientDTO) -> Date {
+    private func lastIncidentDate(for client: Client) -> Date {
         guard let id = client.id else { return .distantPast }
         let dates = incidents
             .filter { $0.clientRef.documentID == id }

--- a/App/FreshWall/FreshWallApp/Clients/EditClientView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/EditClientView.swift
@@ -43,8 +43,8 @@ struct EditClientView: View {
 
 @MainActor
 private class PreviewClientService: ClientServiceProtocol {
-    func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] {
-        [ClientDTO(
+    func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] {
+        [Client(
             id: "client1",
             name: "Sample Client",
             notes: "Preview client",
@@ -61,7 +61,7 @@ private class PreviewClientService: ClientServiceProtocol {
 }
 
 #Preview {
-    let sampleClient = ClientDTO(
+    let sampleClient = Client(
         id: "client123",
         name: "Test Client",
         notes: "Sample notes",

--- a/App/FreshWall/FreshWallApp/Clients/EditClientViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Clients/EditClientViewModel.swift
@@ -18,7 +18,7 @@ final class EditClientViewModel {
         !name.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
-    init(client: ClientDTO, service: ClientServiceProtocol) {
+    init(client: Client, service: ClientServiceProtocol) {
         clientId = client.id ?? ""
         self.service = service
         name = client.name

--- a/App/FreshWall/FreshWallApp/Clients/Models/ClientCellModel.swift
+++ b/App/FreshWall/FreshWallApp/Clients/Models/ClientCellModel.swift
@@ -13,7 +13,7 @@ struct ClientCellModel: Identifiable, Hashable {
 
 extension ClientCellModel {
     /// Generates domain rows from Firestore clients and incidents, filtering out those without IDs.
-    static func makeRows(from clients: [ClientDTO], incidents: [IncidentDTO]) -> [ClientCellModel] {
+    static func makeRows(from clients: [Client], incidents: [Incident]) -> [ClientCellModel] {
         clients.compactMap { client in
             guard let id = client.id else { return nil }
             let lastDate = incidents

--- a/App/FreshWall/FreshWallApp/Clients/Repositories/ClientsRepository.swift
+++ b/App/FreshWall/FreshWallApp/Clients/Repositories/ClientsRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol ClientsRepository {
     /// Fetches active clients for the current team.
-    func fetchClients(sortedBy sortOption: ClientSortOption) async throws -> [ClientDTO]
+    func fetchClients(sortedBy sortOption: ClientSortOption) async throws -> [Client]
     /// Adds a new client using an input value object.
     func addClient(_ input: AddClientInput) async throws
 }
@@ -17,7 +17,7 @@ protocol ClientsRepository {
 struct DefaultClientsRepository: ClientsRepository {
     let client: ClientServiceProtocol
 
-    func fetchClients(sortedBy sortOption: ClientSortOption) async throws -> [ClientDTO] {
+    func fetchClients(sortedBy sortOption: ClientSortOption) async throws -> [Client] {
         try await client.fetchClients(sortedBy: sortOption)
     }
 

--- a/App/FreshWall/FreshWallApp/Domain/IncidentRow.swift
+++ b/App/FreshWall/FreshWallApp/Domain/IncidentRow.swift
@@ -11,7 +11,7 @@ struct IncidentRow: Identifiable, Hashable {
 
 extension IncidentRow {
     /// Generates domain rows from Firestore incidents, filtering out those without IDs.
-    static func makeRows(from incidents: [IncidentDTO]) -> [IncidentRow] {
+    static func makeRows(from incidents: [Incident]) -> [IncidentRow] {
         incidents.compactMap { incident in
             guard let id = incident.id else { return nil }
             return IncidentRow(

--- a/App/FreshWall/FreshWallApp/GenericViews/Label+extension.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/Label+extension.swift
@@ -1,0 +1,31 @@
+//
+//  Label+extension.swift
+//  FreshWall
+//
+//  Created by Gage Halverson on 6/21/25.
+//
+
+import SwiftUI
+
+extension Label where Title == Text, Icon == Image {
+    /// Creates a `Label` whose icon is the SF symbol named `systemImage`
+    /// – **only if** that symbol actually exists on the running OS.
+    ///
+    /// If `systemImage` is `nil`, empty, or unavailable, the label is rendered
+    /// without an icon.
+    nonisolated public init(
+        _ titleKey: LocalizedStringKey,
+        systemImage name: String?
+    ) {
+        // Is the string non-empty *and* does the symbol exist in this OS build?
+        if let name, !name.isEmpty, UIImage(systemName: name) != nil {
+            self.init(titleKey, systemImage: name)
+        } else {
+            self.init {
+                Text(titleKey)
+            } icon: {
+                Image(uiImage: UIImage())          // 0 × 0 transparent image
+            }
+        }
+    }
+}

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
@@ -167,8 +167,8 @@ struct AddIncidentView: View {
 /// Dummy implementations of services for previews.
 @MainActor
 private class PreviewIncidentService: IncidentServiceProtocol {
-    func fetchIncidents() async throws -> [IncidentDTO] { [] }
-    func addIncident(_: IncidentDTO) async throws {}
+    func fetchIncidents() async throws -> [Incident] { [] }
+    func addIncident(_: Incident) async throws {}
     func addIncident(
         _: AddIncidentInput,
         beforeImages _: [Data],
@@ -184,8 +184,8 @@ private class PreviewIncidentService: IncidentServiceProtocol {
 
 @MainActor
 private class PreviewClientService: ClientServiceProtocol {
-    func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] {
-        [ClientDTO(
+    func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] {
+        [Client(
             id: "client1",
             name: "Sample Client",
             notes: "Preview client",

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
@@ -34,7 +34,7 @@ final class AddIncidentViewModel {
     /// Available status options.
     let statusOptions = ["open", "in_progress", "completed"]
     /// Loaded clients for selection.
-    var clients: [ClientDTO] = []
+    var clients: [Client] = []
     private let clientService: ClientServiceProtocol
     private let service: IncidentServiceProtocol
 

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
@@ -161,8 +161,8 @@ struct EditIncidentView: View {
 
 @MainActor
 private class PreviewClientService: ClientServiceProtocol {
-    func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] {
-        [ClientDTO(
+    func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] {
+        [Client(
             id: "client1",
             name: "Sample Client",
             notes: "Preview client",
@@ -181,8 +181,8 @@ private class PreviewClientService: ClientServiceProtocol {
 /// Dummy implementations of services for previews.
 @MainActor
 private class PreviewIncidentService: IncidentServiceProtocol {
-    func fetchIncidents() async throws -> [IncidentDTO] { [] }
-    func addIncident(_: IncidentDTO) async throws {}
+    func fetchIncidents() async throws -> [Incident] { [] }
+    func addIncident(_: Incident) async throws {}
     func addIncident(
         _: AddIncidentInput,
         beforeImages _: [Data],
@@ -197,7 +197,7 @@ private class PreviewIncidentService: IncidentServiceProtocol {
 }
 
 #Preview {
-    let incident = IncidentDTO(
+    let incident = Incident(
         id: "inc1",
         projectTitle: "",
         clientRef: Firestore.firestore().document("teams/t/clients/client1"),

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
@@ -38,7 +38,7 @@ final class EditIncidentViewModel {
     /// Status options for selection.
     let statusOptions = ["open", "in_progress", "completed"]
     /// Loaded clients for selection.
-    var clients: [ClientDTO] = []
+    var clients: [Client] = []
 
     private let incidentId: String
     private let service: IncidentServiceProtocol
@@ -51,7 +51,7 @@ final class EditIncidentViewModel {
             !projectTitle.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
-    init(incident: IncidentDTO, incidentService: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
+    init(incident: Incident, incidentService: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
         incidentId = incident.id ?? ""
         service = incidentService
         self.clientService = clientService

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -3,14 +3,14 @@ import SwiftUI
 
 /// A view displaying detailed information for a specific incident.
 struct IncidentDetailView: View {
-    @State private var incident: IncidentDTO
+    @State private var incident: Incident
     let incidentService: IncidentServiceProtocol
     let clientService: ClientServiceProtocol
     @Environment(RouterPath.self) private var routerPath
-    @State private var client: ClientDTO?
+    @State private var client: Client?
     @State private var showingEdit = false
 
-    init(incident: IncidentDTO, incidentService: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
+    init(incident: Incident, incidentService: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
         _incident = State(wrappedValue: incident)
         self.incidentService = incidentService
         self.clientService = clientService

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentListCell.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentListCell.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// A cell view displaying summary information for an incident.
 struct IncidentListCell: View {
-    let incident: IncidentDTO
+    let incident: Incident
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
@@ -41,7 +41,7 @@ struct IncidentsListView: View {
 
     @ViewBuilder
     private func groupingMenu(
-        groups: [(title: String?, items: [IncidentDTO])],
+            groups: [(title: String?, items: [Incident])],
         collapsedGroups: Binding<Set<Int>>
     ) -> some View {
         Text("Group By")
@@ -110,16 +110,16 @@ struct IncidentsListView: View {
 
 @MainActor
 private class PreviewIncidentService: IncidentServiceProtocol {
-    func fetchIncidents() async throws -> [IncidentDTO] { [] }
-    func addIncident(_: IncidentDTO) async throws {}
+    func fetchIncidents() async throws -> [Incident] { [] }
+    func addIncident(_: Incident) async throws {}
     func addIncident(_: AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
     func updateIncident(_: String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
 }
 
 @MainActor
 private class PreviewClientService: ClientServiceProtocol {
-    func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] {
-        [ClientDTO(
+    func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] {
+        [Client(
             id: "client1",
             name: "Sample Client",
             notes: "Preview client",

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
@@ -68,7 +68,7 @@ struct IncidentsListView: View {
                     viewModel.isAscending = true
                 }
             } label: {
-                let arrow = viewModel.sortField == .alphabetical ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : ""
+                let arrow = viewModel.sortField == .alphabetical ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : nil
                 Label("Alphabetical", systemImage: arrow)
             }
 
@@ -80,14 +80,14 @@ struct IncidentsListView: View {
                     viewModel.isAscending = true
                 }
             } label: {
-                let arrow = viewModel.sortField == .date ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : ""
+                let arrow = viewModel.sortField == .date ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : nil
                 Label("By Date", systemImage: arrow)
             }
         } else {
             Button {
                 viewModel.isAscending.toggle()
             } label: {
-                let arrow = viewModel.sortField == .date ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : ""
+                let arrow = viewModel.sortField == .date ? (viewModel.isAscending ? "arrow.up" : "arrow.down") : nil
                 Label("Order", systemImage: arrow)
             }
 

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
@@ -6,9 +6,9 @@ import Observation
 @Observable
 final class IncidentsListViewModel {
     /// Incidents fetched from the service.
-    var incidents: [IncidentDTO] = []
+    var incidents: [Incident] = []
     /// Clients used for grouping by client name.
-    var clients: [ClientDTO] = []
+    var clients: [Client] = []
     /// Selected grouping option for incidents.
     var groupOption: IncidentGroupOption?
     /// Field used when sorting incidents.
@@ -40,7 +40,7 @@ final class IncidentsListViewModel {
         clients = await (try? clientService.fetchClients(sortedBy: .createdAtAscending)) ?? []
     }
 
-    func groupedIncidents() -> [(title: String?, items: [IncidentDTO])] {
+    func groupedIncidents() -> [(title: String?, items: [Incident])] {
         switch groupOption {
         case .none:
             let sorted = sort(incidents)
@@ -84,7 +84,7 @@ final class IncidentsListViewModel {
     }
 
     /// Sorts incidents using the current sort field and direction.
-    private func sort(_ items: [IncidentDTO]) -> [IncidentDTO] {
+    private func sort(_ items: [Incident]) -> [Incident] {
         switch sortField {
         case .alphabetical:
             return items.sorted { lhs, rhs in

--- a/App/FreshWall/FreshWallApp/Models/Client.swift
+++ b/App/FreshWall/FreshWallApp/Models/Client.swift
@@ -1,0 +1,39 @@
+import FirebaseFirestore
+import Foundation
+
+/// Domain model representing a client used by the UI layer.
+struct Client: Identifiable, Hashable, Sendable {
+    var id: String?
+    var name: String
+    var notes: String?
+    var isDeleted: Bool
+    var deletedAt: Timestamp?
+    var createdAt: Timestamp
+    var lastIncidentAt: Timestamp
+}
+
+extension Client {
+    /// Creates a domain model from a DTO.
+    init(dto: ClientDTO) {
+        self.id = dto.id
+        self.name = dto.name
+        self.notes = dto.notes
+        self.isDeleted = dto.isDeleted
+        self.deletedAt = dto.deletedAt
+        self.createdAt = dto.createdAt
+        self.lastIncidentAt = dto.lastIncidentAt
+    }
+
+    /// Converts the domain model back to a DTO for persistence.
+    var dto: ClientDTO {
+        ClientDTO(
+            id: id,
+            name: name,
+            notes: notes,
+            isDeleted: isDeleted,
+            deletedAt: deletedAt,
+            createdAt: createdAt,
+            lastIncidentAt: lastIncidentAt
+        )
+    }
+}

--- a/App/FreshWall/FreshWallApp/Models/Incident.swift
+++ b/App/FreshWall/FreshWallApp/Models/Incident.swift
@@ -1,0 +1,72 @@
+import FirebaseFirestore
+import Foundation
+
+/// Domain model representing an incident used by the UI layer.
+struct Incident: Identifiable, Hashable, Sendable {
+    var id: String?
+    var projectTitle: String
+    var clientRef: DocumentReference
+    var workerRefs: [DocumentReference]
+    var description: String
+    var area: Double
+    var createdAt: Timestamp
+    var startTime: Timestamp
+    var endTime: Timestamp
+    var beforePhotoUrls: [String]
+    var afterPhotoUrls: [String]
+    var createdBy: DocumentReference
+    var lastModifiedBy: DocumentReference?
+    var lastModifiedAt: Timestamp?
+    var billable: Bool
+    var rate: Double?
+    var status: String
+    var materialsUsed: String?
+}
+
+extension Incident {
+    /// Creates a domain model from a DTO.
+    init(dto: IncidentDTO) {
+        self.id = dto.id
+        self.projectTitle = dto.projectTitle
+        self.clientRef = dto.clientRef
+        self.workerRefs = dto.workerRefs
+        self.description = dto.description
+        self.area = dto.area
+        self.createdAt = dto.createdAt
+        self.startTime = dto.startTime
+        self.endTime = dto.endTime
+        self.beforePhotoUrls = dto.beforePhotoUrls
+        self.afterPhotoUrls = dto.afterPhotoUrls
+        self.createdBy = dto.createdBy
+        self.lastModifiedBy = dto.lastModifiedBy
+        self.lastModifiedAt = dto.lastModifiedAt
+        self.billable = dto.billable
+        self.rate = dto.rate
+        self.status = dto.status
+        self.materialsUsed = dto.materialsUsed
+    }
+
+    /// Converts the domain model back to a DTO for persistence.
+    var dto: IncidentDTO {
+        IncidentDTO(
+            id: id,
+            projectTitle: projectTitle,
+            clientRef: clientRef,
+            workerRefs: workerRefs,
+            description: description,
+            area: area,
+            createdAt: createdAt,
+            startTime: startTime,
+            endTime: endTime,
+            beforePhotoUrls: beforePhotoUrls,
+            afterPhotoUrls: afterPhotoUrls,
+            createdBy: createdBy,
+            lastModifiedBy: lastModifiedBy,
+            lastModifiedAt: lastModifiedAt,
+            billable: billable,
+            rate: rate,
+            status: status,
+            materialsUsed: materialsUsed
+        )
+    }
+}

--- a/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
+++ b/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
@@ -23,11 +23,11 @@ enum RouterDestination: Hashable {
     case clientsList
     /// Screen for adding a new client.
     case addClient
-    case clientDetail(client: ClientDTO)
+    case clientDetail(client: Client)
     case incidentsList
     /// Screen for adding a new incident.
     case addIncident
-    case incidentDetail(incident: IncidentDTO)
+    case incidentDetail(incident: Incident)
     case membersList
     /// Screen for adding a new member.
     case addMember

--- a/App/FreshWall/FreshWallTests/ClientsListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/ClientsListViewModelTests.swift
@@ -5,14 +5,14 @@ import Testing
 @MainActor
 struct ClientsListViewModelTests {
     final class MockClientService: ClientServiceProtocol {
-        func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] { [] }
+        func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] { [] }
         func addClient(_: AddClientInput) async throws {}
         func updateClient(_: String, with _: UpdateClientInput) async throws {}
     }
 
     final class MockIncidentService: IncidentServiceProtocol {
-        func fetchIncidents() async throws -> [IncidentDTO] { [] }
-        func addIncident(_: IncidentDTO) async throws {}
+        func fetchIncidents() async throws -> [Incident] { [] }
+        func addIncident(_: Incident) async throws {}
         func addIncident(_: AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
         func updateIncident(_: String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
     }
@@ -22,8 +22,8 @@ struct ClientsListViewModelTests {
         let incidentService = MockIncidentService()
         let vm = ClientsListViewModel(clientService: clientService, incidentService: incidentService)
         vm.clients = [
-            ClientDTO(id: "1", name: "B", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
-            ClientDTO(id: "2", name: "A", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init())
+            Client(id: "1", name: "B", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
+            Client(id: "2", name: "A", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init())
         ]
         vm.sortField = .alphabetical
         vm.isAscending = true
@@ -38,10 +38,10 @@ struct ClientsListViewModelTests {
         let clientRefA = Firestore.firestore().document("teams/t/clients/a")
         let clientRefB = Firestore.firestore().document("teams/t/clients/b")
         vm.clients = [
-            ClientDTO(id: "a", name: "A", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
-            ClientDTO(id: "b", name: "B", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init())
+            Client(id: "a", name: "A", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
+            Client(id: "b", name: "B", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init())
         ]
-        var first = IncidentDTO(
+        var first = Incident(
             id: "1",
             clientRef: clientRefA,
             workerRefs: [],

--- a/App/FreshWall/FreshWallTests/EditClientViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/EditClientViewModelTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct EditClientViewModelTests {
     final class MockService: ClientServiceProtocol {
         var updateArgs: (String, UpdateClientInput)?
-        func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] { [] }
+        func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] { [] }
         func addClient(_: AddClientInput) async throws {}
         func updateClient(_ clientId: String, with input: UpdateClientInput) async throws {
             updateArgs = (clientId, input)
@@ -15,7 +15,7 @@ struct EditClientViewModelTests {
 
     @Test func validation() {
         let service = MockService()
-        let dto = ClientDTO(
+        let dto = Client(
             id: "1",
             name: "Test",
             notes: nil,
@@ -33,7 +33,7 @@ struct EditClientViewModelTests {
 
     @Test func saveCallsService() async throws {
         let service = MockService()
-        let dto = ClientDTO(
+        let dto = Client(
             id: "1",
             name: "Old",
             notes: nil,

--- a/App/FreshWall/FreshWallTests/EditIncidentViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/EditIncidentViewModelTests.swift
@@ -6,8 +6,8 @@ import Testing
 struct EditIncidentViewModelTests {
     final class MockIncidentService: IncidentServiceProtocol {
         var updateArgs: (String, UpdateIncidentInput)?
-        func fetchIncidents() async throws -> [IncidentDTO] { [] }
-        func addIncident(_: IncidentDTO) async throws {}
+        func fetchIncidents() async throws -> [Incident] { [] }
+        func addIncident(_: Incident) async throws {}
         func addIncident(
             _: AddIncidentInput,
             beforeImages _: [Data],
@@ -24,7 +24,7 @@ struct EditIncidentViewModelTests {
     }
 
     final class MockClientService: ClientServiceProtocol {
-        func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] { [] }
+        func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] { [] }
         func addClient(_: AddClientInput) async throws {}
         func updateClient(_: String, with _: UpdateClientInput) async throws {}
     }
@@ -32,7 +32,7 @@ struct EditIncidentViewModelTests {
     @Test func validation() {
         let incidentService = MockIncidentService()
         let clientService = MockClientService()
-        let incident = IncidentDTO(
+        let incident = Incident(
             id: "1",
             clientRef: Firestore.firestore().document("teams/t/clients/c"),
             workerRefs: [],
@@ -66,7 +66,7 @@ struct EditIncidentViewModelTests {
     @Test func saveCallsService() async throws {
         let incidentService = MockIncidentService()
         let clientService = MockClientService()
-        let incident = IncidentDTO(
+        let incident = Incident(
             id: "1",
             clientRef: Firestore.firestore().document("teams/t/clients/c"),
             workerRefs: [],

--- a/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
@@ -5,14 +5,14 @@ import Testing
 @MainActor
 struct IncidentsListViewModelTests {
     final class MockService: IncidentServiceProtocol {
-        func fetchIncidents() async throws -> [IncidentDTO] { [] }
-        func addIncident(_: IncidentDTO) async throws {}
+        func fetchIncidents() async throws -> [Incident] { [] }
+        func addIncident(_: Incident) async throws {}
         func addIncident(_: AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
         func updateIncident(_: String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
     }
 
     final class MockClientService: ClientServiceProtocol {
-        func fetchClients(sortedBy _: ClientSortOption) async throws -> [ClientDTO] { [] }
+        func fetchClients(sortedBy _: ClientSortOption) async throws -> [Client] { [] }
         func addClient(_: AddClientInput) async throws {}
         func updateClient(_: String, with _: UpdateClientInput) async throws {}
     }
@@ -23,7 +23,7 @@ struct IncidentsListViewModelTests {
         let vm = IncidentsListViewModel(incidentService: service, clientService: clientService)
         let clientRefA = Firestore.firestore().document("teams/t/clients/a")
         let clientRefB = Firestore.firestore().document("teams/t/clients/b")
-        let baseIncident = IncidentDTO(
+        let baseIncident = Incident(
             id: "1",
             clientRef: clientRefA,
             workerRefs: [],
@@ -49,8 +49,8 @@ struct IncidentsListViewModelTests {
         vm.incidents = [baseIncident, second]
         vm.groupOption = .client
         vm.clients = [
-            ClientDTO(id: "a", name: "A", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
-            ClientDTO(id: "b", name: "B", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
+            Client(id: "a", name: "A", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
+            Client(id: "b", name: "B", notes: nil, isDeleted: false, deletedAt: nil, createdAt: .init(), lastIncidentAt: .init()),
         ]
 
         vm.isAscending = true
@@ -79,7 +79,7 @@ struct IncidentsListViewModelTests {
         let clientRef = Firestore.firestore().document("teams/t/clients/a")
         let baseDate = Date()
         let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: baseDate)!
-        let first = IncidentDTO(
+        let first = Incident(
             id: "1",
             clientRef: clientRef,
             workerRefs: [],
@@ -125,7 +125,7 @@ struct IncidentsListViewModelTests {
         let clientService = MockClientService()
         let vm = IncidentsListViewModel(incidentService: service, clientService: clientService)
         let clientRef = Firestore.firestore().document("teams/t/clients/a")
-        var first = IncidentDTO(
+        var first = Incident(
             id: "1",
             clientRef: clientRef,
             workerRefs: [],
@@ -164,7 +164,7 @@ struct IncidentsListViewModelTests {
         let clientRef = Firestore.firestore().document("teams/t/clients/a")
         let baseDate = Date()
         let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: baseDate)!
-        var first = IncidentDTO(
+        var first = Incident(
             id: "1",
             clientRef: clientRef,
             workerRefs: [],


### PR DESCRIPTION
## Summary
- introduce `Client` and `Incident` domain models
- convert services to output domain models
- update router, view models, and views to use new models
- adjust unit tests to the new APIs

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68576db915e0832fa26ff46bf762f1ab