### PR TITLE
Add photo metadata service

### DIFF
--- a/App/FreshWall/FreshWallApp/Services/PhotoMetadataService.swift
+++ b/App/FreshWall/FreshWallApp/Services/PhotoMetadataService.swift
@@ -1,3 +1,4 @@
+import _PhotosUI_SwiftUI
 import CoreLocation
 import ImageIO
 import Photos
@@ -43,12 +44,14 @@ struct PhotoMetadataService: PhotoMetadataServiceProtocol {
 
         var date: Date?
         if let exif = properties[kCGImagePropertyExifDictionary] as? [CFString: Any],
-           let dateString = exif[kCGImagePropertyExifDateTimeOriginal] as? String {
+           let dateString = exif[kCGImagePropertyExifDateTimeOriginal] as? String
+        {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy:MM:dd HH:mm:ss"
             date = formatter.date(from: dateString)
         } else if let tiff = properties[kCGImagePropertyTIFFDictionary] as? [CFString: Any],
-                  let dateString = tiff[kCGImagePropertyTIFFDateTime] as? String {
+                  let dateString = tiff[kCGImagePropertyTIFFDateTime] as? String
+        {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy:MM:dd HH:mm:ss"
             date = formatter.date(from: dateString)
@@ -59,7 +62,8 @@ struct PhotoMetadataService: PhotoMetadataServiceProtocol {
            let lat = gps[kCGImagePropertyGPSLatitude] as? Double,
            let latRef = gps[kCGImagePropertyGPSLatitudeRef] as? String,
            let lon = gps[kCGImagePropertyGPSLongitude] as? Double,
-           let lonRef = gps[kCGImagePropertyGPSLongitudeRef] as? String {
+           let lonRef = gps[kCGImagePropertyGPSLongitudeRef] as? String
+        {
             let latitude = latRef == "S" ? -lat : lat
             let longitude = lonRef == "W" ? -lon : lon
             location = CLLocation(latitude: latitude, longitude: longitude)

--- a/App/FreshWall/FreshWallApp/Services/PhotoMetadataService.swift
+++ b/App/FreshWall/FreshWallApp/Services/PhotoMetadataService.swift
@@ -1,0 +1,70 @@
+import CoreLocation
+import ImageIO
+import Photos
+import PhotosUI
+
+/// Metadata extracted from an image.
+struct PhotoMetadata: Sendable {
+    /// Date the photo was captured if available.
+    let captureDate: Date?
+    /// Location the photo was captured if available.
+    let location: CLLocation?
+}
+
+/// Protocol for loading metadata from selected photos.
+protocol PhotoMetadataServiceProtocol: Sendable {
+    /// Extract metadata from a picker item.
+    func metadata(for item: PhotosPickerItem) async throws -> PhotoMetadata
+    /// Extract metadata from raw image data.
+    func metadata(from data: Data) -> PhotoMetadata
+}
+
+/// Default metadata service using `Photos` and `ImageIO`.
+struct PhotoMetadataService: PhotoMetadataServiceProtocol {
+    func metadata(for item: PhotosPickerItem) async throws -> PhotoMetadata {
+        if let id = item.itemIdentifier {
+            let assets = PHAsset.fetchAssets(withLocalIdentifiers: [id], options: nil)
+            if let asset = assets.firstObject {
+                return PhotoMetadata(captureDate: asset.creationDate, location: asset.location)
+            }
+        }
+        if let data = try? await item.loadTransferable(type: Data.self) {
+            return metadata(from: data)
+        }
+        return PhotoMetadata(captureDate: nil, location: nil)
+    }
+
+    func metadata(from data: Data) -> PhotoMetadata {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+        else {
+            return PhotoMetadata(captureDate: nil, location: nil)
+        }
+
+        var date: Date?
+        if let exif = properties[kCGImagePropertyExifDictionary] as? [CFString: Any],
+           let dateString = exif[kCGImagePropertyExifDateTimeOriginal] as? String {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy:MM:dd HH:mm:ss"
+            date = formatter.date(from: dateString)
+        } else if let tiff = properties[kCGImagePropertyTIFFDictionary] as? [CFString: Any],
+                  let dateString = tiff[kCGImagePropertyTIFFDateTime] as? String {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy:MM:dd HH:mm:ss"
+            date = formatter.date(from: dateString)
+        }
+
+        var location: CLLocation?
+        if let gps = properties[kCGImagePropertyGPSDictionary] as? [CFString: Any],
+           let lat = gps[kCGImagePropertyGPSLatitude] as? Double,
+           let latRef = gps[kCGImagePropertyGPSLatitudeRef] as? String,
+           let lon = gps[kCGImagePropertyGPSLongitude] as? Double,
+           let lonRef = gps[kCGImagePropertyGPSLongitudeRef] as? String {
+            let latitude = latRef == "S" ? -lat : lat
+            let longitude = lonRef == "W" ? -lon : lon
+            location = CLLocation(latitude: latitude, longitude: longitude)
+        }
+
+        return PhotoMetadata(captureDate: date, location: location)
+    }
+}

--- a/App/FreshWall/FreshWallTests/PhotoMetadataServiceTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoMetadataServiceTests.swift
@@ -1,0 +1,59 @@
+import CoreLocation
+@testable import FreshWall
+import Testing
+import UniformTypeIdentifiers
+
+struct PhotoMetadataServiceTests {
+    private func makeTestImageData() -> Data {
+        let width = 1
+        let height = 1
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+        var pixel: [UInt8] = [255, 0, 0, 255]
+        let provider = CGDataProvider(data: Data(pixel) as CFData)!
+        let cgImage = CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        )!
+
+        let metaData = NSMutableData()
+        let dest = CGImageDestinationCreateWithData(metaData, UTType.jpeg.identifier as CFString, 1, nil)!
+        let exif: [CFString: Any] = [kCGImagePropertyExifDateTimeOriginal: "2023:12:31 10:00:00"]
+        let gps: [CFString: Any] = [
+            kCGImagePropertyGPSLatitude: 37.0,
+            kCGImagePropertyGPSLatitudeRef: "N",
+            kCGImagePropertyGPSLongitude: 122.0,
+            kCGImagePropertyGPSLongitudeRef: "W"
+        ]
+        let props: [CFString: Any] = [
+            kCGImagePropertyExifDictionary: exif,
+            kCGImagePropertyGPSDictionary: gps
+        ]
+        CGImageDestinationAddImage(dest, cgImage, props as CFDictionary)
+        CGImageDestinationFinalize(dest)
+        return metaData as Data
+    }
+
+    @Test func parseMetadataFromData() {
+        let data = makeTestImageData()
+        let service = PhotoMetadataService()
+        let meta = service.metadata(from: data)
+        #expect(meta.location?.coordinate.latitude == 37.0)
+        #expect(meta.location?.coordinate.longitude == -122.0)
+        let comps = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: meta.captureDate ?? .distantPast)
+        #expect(comps.year == 2023)
+        #expect(comps.month == 12)
+        #expect(comps.day == 31)
+        #expect(comps.hour == 10)
+        #expect(comps.minute == 0)
+    }
+}


### PR DESCRIPTION
## Summary
- add `PhotoMetadataService` to extract location & date from an image
- create `PhotoMetadataServiceTests` demonstrating metadata parsing

## Testing
- `npm test` *(fails: biome not found)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68578d6b5bfc832fa41fc13acb3fadb0