### PR TITLE
Add pull-to-refresh support

### DIFF
--- a/App/FreshWall/FreshWallApp/Clients/ClientsListView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientsListView.swift
@@ -21,7 +21,7 @@ struct ClientsListView: View {
         GenericListView(
             items: viewModel.sortedClients(),
             title: "Clients",
-            destination: { client in .clientDetail(client: client) },
+            routerDestination: { client in .clientDetail(client: client) },
             content: { client in ClientListCell(client: client) },
             plusButtonAction: {
                 routerPath.push(.addClient)

--- a/App/FreshWall/FreshWallApp/Clients/ClientsListView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientsListView.swift
@@ -26,6 +26,10 @@ struct ClientsListView: View {
             plusButtonAction: {
                 routerPath.push(.addClient)
             },
+            refreshAction: {
+                await viewModel.loadClients()
+                await viewModel.loadIncidents()
+            },
             menu: {
                 Menu {
                     sortingMenu

--- a/App/FreshWall/FreshWallApp/GenericViews/AsyncSheet.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/AsyncSheet.swift
@@ -12,8 +12,12 @@ extension View {
         onDismiss: @escaping () async -> Void,
         @ViewBuilder content: @escaping () -> some View
     ) -> some View {
-        sheet(isPresented: isPresented, onDismiss: {
-            Task { await onDismiss() }
-        }, content: content)
+        sheet(
+            isPresented: isPresented,
+            onDismiss: {
+                Task { await onDismiss() }
+            },
+            content: content
+        )
     }
 }

--- a/App/FreshWall/FreshWallApp/GenericViews/GenericGroupableListView.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/GenericGroupableListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// A generic view for displaying items grouped into sections with a menu for selecting a grouping option.
 struct GenericGroupableListView<
     Item: Identifiable,
+    Destination: Hashable,
     GroupOption: CaseIterable & Hashable & RawRepresentable,
     Content: View,
     MenuContent: View
@@ -14,7 +15,7 @@ struct GenericGroupableListView<
     /// Currently selected grouping option (nil means no grouping).
     @Binding var groupOption: GroupOption?
     /// Produces a navigation destination for a given item.
-    var destination: (Item) -> RouterDestination
+    var destination: (Item) -> Destination
     /// Creates the content view for a given item.
     var content: (Item) -> Content
 
@@ -29,7 +30,7 @@ struct GenericGroupableListView<
         groups: [(title: String?, items: [Item])],
         title: String,
         groupOption: Binding<GroupOption?>,
-        destination: @escaping (Item) -> RouterDestination,
+        destination: @escaping (Item) -> Destination,
         content: @escaping (Item) -> Content,
         plusButtonAction: @escaping @MainActor () -> Void,
         refreshAction: @escaping @MainActor () async -> Void = {},
@@ -109,5 +110,29 @@ struct GenericGroupableListView<
         } else {
             collapsedGroups.insert(index)
         }
+    }
+}
+
+extension GenericGroupableListView where Destination == RouterDestination {
+    init(
+        groups: [(title: String?, items: [Item])],
+        title: String,
+        groupOption: Binding<GroupOption?>,
+        routerDestination: @escaping (Item) -> RouterDestination,
+        content: @escaping (Item) -> Content,
+        plusButtonAction: @escaping @MainActor () -> Void,
+        refreshAction: @escaping @MainActor () async -> Void = {},
+        @ViewBuilder menu: @escaping (_ collapsedGroups: Binding<Set<Int>>) -> MenuContent = { _ in EmptyView() }
+    ) {
+        self.init(
+            groups: groups,
+            title: title,
+            groupOption: groupOption,
+            destination: routerDestination,
+            content: content,
+            plusButtonAction: plusButtonAction,
+            refreshAction: refreshAction,
+            menu: menu
+        )
     }
 }

--- a/App/FreshWall/FreshWallApp/GenericViews/GenericGroupableListView.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/GenericGroupableListView.swift
@@ -19,6 +19,7 @@ struct GenericGroupableListView<
     var content: (Item) -> Content
 
     let plusButtonAction: @MainActor () -> Void
+    let refreshAction: @MainActor () async -> Void
     @ViewBuilder var menu: (_ collapsedGroups: Binding<Set<Int>>) -> MenuContent
 
     /// Tracks which groups are collapsed by index when grouping is enabled.
@@ -31,6 +32,7 @@ struct GenericGroupableListView<
         destination: @escaping (Item) -> RouterDestination,
         content: @escaping (Item) -> Content,
         plusButtonAction: @escaping @MainActor () -> Void,
+        refreshAction: @escaping @MainActor () async -> Void = {},
         @ViewBuilder menu: @escaping (_ collapsedGroups: Binding<Set<Int>>) -> MenuContent = { _ in EmptyView() }
     ) {
         self.groups = groups
@@ -39,6 +41,7 @@ struct GenericGroupableListView<
         self.destination = destination
         self.content = content
         self.plusButtonAction = plusButtonAction
+        self.refreshAction = refreshAction
         self.menu = menu
     }
 
@@ -86,6 +89,7 @@ struct GenericGroupableListView<
             }
             .animation(.easeInOut(duration: 0.2), value: collapsedGroups)
         }
+        .refreshable { await refreshAction() }
         .scrollIndicators(.hidden)
         .navigationTitle(title)
         .toolbar {

--- a/App/FreshWall/FreshWallApp/GenericViews/GenericListView.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/GenericListView.swift
@@ -22,7 +22,7 @@ struct GenericListView<
         content: @escaping (Item) -> Content,
         plusButtonAction: @escaping @MainActor () -> Void,
         refreshAction: @escaping @MainActor () async -> Void,
-        @ViewBuilder menu: @escaping () -> MenuContent = { EmptyView() }
+        @ViewBuilder menu: @escaping () -> MenuContent
     ) {
         self.items = items
         self.title = title

--- a/App/FreshWall/FreshWallApp/GenericViews/GenericListView.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/GenericListView.swift
@@ -7,6 +7,7 @@ struct GenericListView<Item: Identifiable, Content: View, MenuContent: View>: Vi
     var content: (Item) -> Content
 
     let plusButtonAction: @MainActor () -> Void
+    let refreshAction: @MainActor () async -> Void
     @ViewBuilder var menu: () -> MenuContent
 
     init(
@@ -15,6 +16,7 @@ struct GenericListView<Item: Identifiable, Content: View, MenuContent: View>: Vi
         destination: @escaping (Item) -> RouterDestination,
         content: @escaping (Item) -> Content,
         plusButtonAction: @escaping @MainActor () -> Void,
+        refreshAction: @escaping @MainActor () async -> Void = {},
         @ViewBuilder menu: @escaping () -> MenuContent = { EmptyView() }
     ) {
         self.items = items
@@ -22,6 +24,7 @@ struct GenericListView<Item: Identifiable, Content: View, MenuContent: View>: Vi
         self.destination = destination
         self.content = content
         self.plusButtonAction = plusButtonAction
+        self.refreshAction = refreshAction
         self.menu = menu
     }
 
@@ -37,6 +40,7 @@ struct GenericListView<Item: Identifiable, Content: View, MenuContent: View>: Vi
                 .padding(.horizontal)
             }
         }
+        .refreshable { await refreshAction() }
         .scrollIndicators(.hidden)
         .navigationTitle(title)
         .toolbar {

--- a/App/FreshWall/FreshWallApp/GenericViews/GenericListView.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/GenericListView.swift
@@ -1,9 +1,14 @@
 import SwiftUI
 
-struct GenericListView<Item: Identifiable, Content: View, MenuContent: View>: View {
+struct GenericListView<
+    Item: Identifiable,
+    Destination: Hashable,
+    Content: View,
+    MenuContent: View
+>: View {
     var items: [Item]
     var title: String
-    var destination: (Item) -> RouterDestination
+    var destination: (Item) -> Destination
     var content: (Item) -> Content
 
     let plusButtonAction: @MainActor () -> Void
@@ -13,10 +18,10 @@ struct GenericListView<Item: Identifiable, Content: View, MenuContent: View>: Vi
     init(
         items: [Item],
         title: String,
-        destination: @escaping (Item) -> RouterDestination,
+        destination: @escaping (Item) -> Destination,
         content: @escaping (Item) -> Content,
         plusButtonAction: @escaping @MainActor () -> Void,
-        refreshAction: @escaping @MainActor () async -> Void = {},
+        refreshAction: @escaping @MainActor () async -> Void,
         @ViewBuilder menu: @escaping () -> MenuContent = { EmptyView() }
     ) {
         self.items = items
@@ -53,5 +58,27 @@ struct GenericListView<Item: Identifiable, Content: View, MenuContent: View>: Vi
                 }
             }
         }
+    }
+}
+
+extension GenericListView where Destination == RouterDestination {
+    init(
+        items: [Item],
+        title: String,
+        routerDestination: @escaping (Item) -> RouterDestination,
+        content: @escaping (Item) -> Content,
+        plusButtonAction: @escaping @MainActor () -> Void,
+        refreshAction: @escaping @MainActor () async -> Void = {},
+        @ViewBuilder menu: @escaping () -> MenuContent = { EmptyView() }
+    ) {
+        self.init(
+            items: items,
+            title: title,
+            destination: routerDestination,
+            content: content,
+            plusButtonAction: plusButtonAction,
+            refreshAction: refreshAction,
+            menu: menu
+        )
     }
 }

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
@@ -23,6 +23,10 @@ struct IncidentsListView: View {
             plusButtonAction: {
                 routerPath.push(.addIncident)
             },
+            refreshAction: {
+                await viewModel.loadIncidents()
+                await viewModel.loadClients()
+            },
             menu: { collapsedGroups in
                 Menu {
                     groupingMenu(groups: viewModel.groupedIncidents(), collapsedGroups: collapsedGroups)

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
@@ -16,7 +16,7 @@ struct IncidentsListView: View {
             groups: viewModel.groupedIncidents(),
             title: "Incidents",
             groupOption: $viewModel.groupOption,
-            destination: { incident in .incidentDetail(incident: incident) },
+            routerDestination: { incident in .incidentDetail(incident: incident) },
             content: { incident in
                 IncidentListCell(incident: incident)
             },

--- a/App/FreshWall/FreshWallApp/Members/MembersListView.swift
+++ b/App/FreshWall/FreshWallApp/Members/MembersListView.swift
@@ -17,7 +17,7 @@ struct MembersListView: View {
         GenericListView(
             items: viewModel.members,
             title: "Members",
-            destination: { member in .memberDetail(member: member) },
+            routerDestination: { member in .memberDetail(member: member) },
             content: { member in
                 MemberListCell(member: member)
             },

--- a/App/FreshWall/FreshWallApp/Members/MembersListView.swift
+++ b/App/FreshWall/FreshWallApp/Members/MembersListView.swift
@@ -23,6 +23,9 @@ struct MembersListView: View {
             },
             plusButtonAction: {
                 routerPath.push(.inviteMember)
+            },
+            refreshAction: {
+                await viewModel.loadMembers()
             }
         )
         .task {

--- a/App/FreshWall/FreshWallTests/GenericGroupableListViewTests.swift
+++ b/App/FreshWall/FreshWallTests/GenericGroupableListViewTests.swift
@@ -12,11 +12,10 @@ struct GenericGroupableListViewTests {
             groups: groups,
             title: "Test",
             groupOption: .constant(.none),
-            sortField: .constant(.date),
-            isAscending: .constant(true),
             destination: { _ in .clientsList },
             content: { _ in EmptyView() },
-            plusButtonAction: {}
+            plusButtonAction: {},
+            refreshAction: {}
         )
     }
 }

--- a/App/FreshWall/FreshWallTests/PhotoMetadataServiceTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoMetadataServiceTests.swift
@@ -32,11 +32,11 @@ struct PhotoMetadataServiceTests {
             kCGImagePropertyGPSLatitude: 37.0,
             kCGImagePropertyGPSLatitudeRef: "N",
             kCGImagePropertyGPSLongitude: 122.0,
-            kCGImagePropertyGPSLongitudeRef: "W"
+            kCGImagePropertyGPSLongitudeRef: "W",
         ]
         let props: [CFString: Any] = [
             kCGImagePropertyExifDictionary: exif,
-            kCGImagePropertyGPSDictionary: gps
+            kCGImagePropertyGPSDictionary: gps,
         ]
         CGImageDestinationAddImage(dest, cgImage, props as CFDictionary)
         CGImageDestinationFinalize(dest)


### PR DESCRIPTION
## Summary
- add refreshable closure to GenericListView and GenericGroupableListView
- enable pull to refresh on incidents, members and clients lists
- update tests for new initializer

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm run build` *(fails: missing modules)*
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*
- `swift test --enable-code-coverage` *(fails: toolchain 6.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685799121cb4832fa846f6e29281cbcb