### PR TITLE
Add grouping and sorting to members list

### DIFF
--- a/App/FreshWall/FreshWallApp/MainAppView.swift
+++ b/App/FreshWall/FreshWallApp/MainAppView.swift
@@ -50,7 +50,8 @@ struct MainAppView: View {
                 .withAppRouter(
                     clientService: clientService,
                     incidentService: incidentService,
-                    memberService: memberService
+                    memberService: memberService,
+                    currentUserId: sessionStore.session.userId
                 )
         }
         .environment(routerPath)

--- a/App/FreshWall/FreshWallApp/Members/MemberGroupOption.swift
+++ b/App/FreshWall/FreshWallApp/Members/MemberGroupOption.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Options for grouping members in the list view.
+enum MemberGroupOption: String, CaseIterable {
+    /// Group members by their role within the team.
+    case role = "Role"
+}

--- a/App/FreshWall/FreshWallApp/Members/MemberSortField.swift
+++ b/App/FreshWall/FreshWallApp/Members/MemberSortField.swift
@@ -16,6 +16,7 @@ enum MemberSortField: SortFieldRepresentable {
 
     func icon(isSelected: Bool, isAscending: Bool) -> String? {
         guard isSelected else { return nil }
+
         return isAscending ? "arrow.up" : "arrow.down"
     }
 }

--- a/App/FreshWall/FreshWallApp/Members/MemberSortField.swift
+++ b/App/FreshWall/FreshWallApp/Members/MemberSortField.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Fields available for sorting members.
+enum MemberSortField: SortFieldRepresentable {
+    /// Sort by display name alphabetically.
+    case alphabetical
+    /// Sort by role type.
+    case role
+
+    var label: String {
+        switch self {
+        case .alphabetical: "Alphabetical"
+        case .role: "Role"
+        }
+    }
+
+    func icon(isSelected: Bool, isAscending: Bool) -> String? {
+        guard isSelected else { return nil }
+        return isAscending ? "arrow.up" : "arrow.down"
+    }
+}

--- a/App/FreshWall/FreshWallApp/Members/MembersListView.swift
+++ b/App/FreshWall/FreshWallApp/Members/MembersListView.swift
@@ -4,19 +4,27 @@ import SwiftUI
 /// A view displaying a list of team members.
 struct MembersListView: View {
     let service: MemberServiceProtocol
+    let currentUserId: String
     @Environment(RouterPath.self) private var routerPath
     @State private var viewModel: MembersListViewModel
 
     /// Initializes the view with a member service implementing `MemberServiceProtocol`.
-    init(service: MemberServiceProtocol) {
+    init(service: MemberServiceProtocol, currentUserId: String) {
         self.service = service
-        _viewModel = State(wrappedValue: MembersListViewModel(service: service))
+        self.currentUserId = currentUserId
+        _viewModel = State(
+            wrappedValue: MembersListViewModel(
+                service: service,
+                currentUserId: currentUserId
+            )
+        )
     }
 
     var body: some View {
-        GenericListView(
-            items: viewModel.members,
+        GenericGroupableListView(
+            groups: viewModel.groupedMembers(),
             title: "Members",
+            groupOption: $viewModel.groupOption,
             routerDestination: { member in .memberDetail(member: member) },
             content: { member in
                 MemberListCell(member: member)
@@ -26,10 +34,71 @@ struct MembersListView: View {
             },
             refreshAction: {
                 await viewModel.loadMembers()
+            },
+            menu: { collapsedGroups in
+                Menu {
+                    groupingMenu(
+                        groups: viewModel.groupedMembers(),
+                        collapsedGroups: collapsedGroups
+                    )
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                }
             }
         )
+        .onChange(of: viewModel.sort) { _, _ in viewModel.userSelectedSort = true }
         .task {
             await viewModel.loadMembers()
+        }
+    }
+
+    @ViewBuilder
+    private func groupingMenu(
+        groups: [(title: String?, items: [Member])],
+        collapsedGroups: Binding<Set<Int>>
+    ) -> some View {
+        Text("Group By")
+            .font(.caption)
+            .foregroundColor(.secondary)
+
+        Picker("Group By", selection: $viewModel.groupOption) {
+            Text("None").tag(MemberGroupOption?.none)
+            ForEach(MemberGroupOption.allCases, id: \.self) { option in
+                Text(option.rawValue).tag(Optional.some(option))
+            }
+        }
+
+        Text("Sort By")
+            .font(.caption)
+            .foregroundColor(.secondary)
+
+        if viewModel.groupOption == nil {
+            SortButton(for: .alphabetical, sort: $viewModel.sort)
+            SortButton(for: .role, sort: $viewModel.sort)
+        } else {
+            SortButton(for: .alphabetical, sort: $viewModel.sort)
+            collapseToggleButton(groups: groups, collapsedGroups: collapsedGroups)
+        }
+    }
+
+    @ViewBuilder
+    private func collapseToggleButton(
+        groups: [(title: String?, items: [Member])],
+        collapsedGroups: Binding<Set<Int>>
+    ) -> some View {
+        let allCollapsed = collapsedGroups.wrappedValue.count == groups.count
+
+        Button {
+            if allCollapsed {
+                collapsedGroups.wrappedValue.removeAll()
+            } else {
+                collapsedGroups.wrappedValue = Set(groups.indices)
+            }
+        } label: {
+            Label(
+                allCollapsed ? "Uncollapse All" : "Collapse All",
+                systemImage: allCollapsed ? "chevron.down" : "chevron.right"
+            )
         }
     }
 }
@@ -47,7 +116,10 @@ struct MembersListView: View {
     )
     FreshWallPreview {
         NavigationStack {
-            MembersListView(service: service)
+            MembersListView(
+                service: service,
+                currentUserId: ""
+            )
         }
     }
 }

--- a/App/FreshWall/FreshWallApp/Members/MembersListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Members/MembersListViewModel.swift
@@ -6,15 +6,87 @@ import Observation
 final class MembersListViewModel {
     /// Team members fetched from the service.
     var members: [Member] = []
-    private let service: MemberServiceProtocol
+    /// Selected grouping option for the list.
+    var groupOption: MemberGroupOption?
+    /// Sort state for members.
+    var sort: SortState<MemberSortField> = .init(field: .alphabetical, isAscending: true) {
+        didSet {
+            if oldValue != sort {
+                userSelectedSort = true
+            }
+        }
+    }
+    /// Indicates whether the user manually changed the sort order.
+    private(set) var userSelectedSort = false
 
-    /// Initializes the view model with a service conforming to `MemberServiceProtocol`.
-    init(service: MemberServiceProtocol) {
+    private let service: MemberServiceProtocol
+    private let currentUserId: String
+
+    /// Initializes the view model with a service conforming to `MemberServiceProtocol` and the current user id.
+    init(service: MemberServiceProtocol, currentUserId: String) {
         self.service = service
+        self.currentUserId = currentUserId
     }
 
     /// Loads members from the service.
     func loadMembers() async {
         members = await (try? service.fetchMembers()) ?? []
+    }
+
+    /// Returns members grouped and sorted based on the selected options.
+    func groupedMembers() -> [(title: String?, items: [Member])] {
+        switch groupOption {
+        case .role:
+            let groups = Dictionary(grouping: members) { $0.role.rawValue.capitalized }
+            return groups
+                .map { key, value in
+                    (title: key, items: sortMembers(value))
+                }
+                .sorted { lhs, rhs in
+                    let lhsTitle = lhs.title ?? ""
+                    let rhsTitle = rhs.title ?? ""
+                    return sort.isAscending ? lhsTitle < rhsTitle : lhsTitle > rhsTitle
+                }
+        case nil:
+            let sorted = sortedMembers()
+            return [(nil, sorted)]
+        }
+    }
+
+    /// Returns members sorted based on the current sort field and direction.
+    func sortedMembers() -> [Member] {
+        var result = sortMembers(members)
+
+        if !userSelectedSort && sort.field == .alphabetical && groupOption == nil {
+            if let index = result.firstIndex(where: { $0.id == currentUserId }) {
+                let current = result.remove(at: index)
+                result.insert(current, at: 0)
+            }
+        }
+
+        return result
+    }
+
+    private func sortMembers(_ items: [Member]) -> [Member] {
+        switch sort.field {
+        case .alphabetical:
+            return items.sorted { lhs, rhs in
+                if sort.isAscending {
+                    lhs.displayName < rhs.displayName
+                } else {
+                    lhs.displayName > rhs.displayName
+                }
+            }
+        case .role:
+            return items.sorted { lhs, rhs in
+                let lhsRole = lhs.role.rawValue
+                let rhsRole = rhs.role.rawValue
+                if sort.isAscending {
+                    return lhsRole < rhsRole
+                } else {
+                    return lhsRole > rhsRole
+                }
+            }
+        }
     }
 }

--- a/App/FreshWall/FreshWallApp/Members/MembersListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Members/MembersListViewModel.swift
@@ -16,8 +16,9 @@ final class MembersListViewModel {
             }
         }
     }
+
     /// Indicates whether the user manually changed the sort order.
-    private(set) var userSelectedSort = false
+    var userSelectedSort = false
 
     private let service: MemberServiceProtocol
     private let currentUserId: String
@@ -57,7 +58,7 @@ final class MembersListViewModel {
     func sortedMembers() -> [Member] {
         var result = sortMembers(members)
 
-        if !userSelectedSort && sort.field == .alphabetical && groupOption == nil {
+        if !userSelectedSort, sort.field == .alphabetical, groupOption == nil {
             if let index = result.firstIndex(where: { $0.id == currentUserId }) {
                 let current = result.remove(at: index)
                 result.insert(current, at: 0)
@@ -70,7 +71,7 @@ final class MembersListViewModel {
     private func sortMembers(_ items: [Member]) -> [Member] {
         switch sort.field {
         case .alphabetical:
-            return items.sorted { lhs, rhs in
+            items.sorted { lhs, rhs in
                 if sort.isAscending {
                     lhs.displayName < rhs.displayName
                 } else {
@@ -78,7 +79,7 @@ final class MembersListViewModel {
                 }
             }
         case .role:
-            return items.sorted { lhs, rhs in
+            items.sorted { lhs, rhs in
                 let lhsRole = lhs.role.rawValue
                 let rhsRole = rhs.role.rawValue
                 if sort.isAscending {

--- a/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
+++ b/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
@@ -44,7 +44,8 @@ extension View {
     func withAppRouter(
         clientService: ClientServiceProtocol,
         incidentService: IncidentServiceProtocol,
-        memberService: MemberServiceProtocol
+        memberService: MemberServiceProtocol,
+        currentUserId: String
     ) -> some View {
         navigationDestination(for: RouterDestination.self) { destination in
             switch destination {
@@ -82,7 +83,10 @@ extension View {
                     clientService: clientService
                 )
             case .membersList:
-                MembersListView(service: memberService)
+                MembersListView(
+                    service: memberService,
+                    currentUserId: currentUserId
+                )
             case .inviteMember:
                 InviteMemberView(service: InviteCodeService())
             case let .memberDetail(member):

--- a/App/FreshWall/FreshWallTests/MembersListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/MembersListViewModelTests.swift
@@ -1,11 +1,11 @@
-import Testing
 @testable import FreshWall
+import Testing
 
 @MainActor
 struct MembersListViewModelTests {
     final class MockService: MemberServiceProtocol {
         func fetchMembers() async throws -> [Member] { [] }
-        func addMember(_ input: AddMemberInput) async throws {}
+        func addMember(_: AddMemberInput) async throws {}
     }
 
     @Test func groupingByRole() {
@@ -13,7 +13,7 @@ struct MembersListViewModelTests {
         let vm = MembersListViewModel(service: service, currentUserId: "1")
         vm.members = [
             Member(id: "1", displayName: "Alice", email: "a", role: .lead, isDeleted: false, deletedAt: nil),
-            Member(id: "2", displayName: "Bob", email: "b", role: .member, isDeleted: false, deletedAt: nil)
+            Member(id: "2", displayName: "Bob", email: "b", role: .member, isDeleted: false, deletedAt: nil),
         ]
         vm.groupOption = .role
         let groups = vm.groupedMembers()
@@ -26,7 +26,7 @@ struct MembersListViewModelTests {
         let vm = MembersListViewModel(service: service, currentUserId: "2")
         vm.members = [
             Member(id: "1", displayName: "A", email: "", role: .member, isDeleted: false, deletedAt: nil),
-            Member(id: "2", displayName: "B", email: "", role: .member, isDeleted: false, deletedAt: nil)
+            Member(id: "2", displayName: "B", email: "", role: .member, isDeleted: false, deletedAt: nil),
         ]
         let sorted = vm.sortedMembers()
         #expect(sorted.first?.id == "2")
@@ -37,7 +37,7 @@ struct MembersListViewModelTests {
         let vm = MembersListViewModel(service: service, currentUserId: "2")
         vm.members = [
             Member(id: "1", displayName: "A", email: "", role: .lead, isDeleted: false, deletedAt: nil),
-            Member(id: "2", displayName: "B", email: "", role: .member, isDeleted: false, deletedAt: nil)
+            Member(id: "2", displayName: "B", email: "", role: .member, isDeleted: false, deletedAt: nil),
         ]
         vm.sort.toggleOrSelect(.role)
         let sorted = vm.sortedMembers()

--- a/App/FreshWall/FreshWallTests/MembersListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/MembersListViewModelTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import FreshWall
+
+@MainActor
+struct MembersListViewModelTests {
+    final class MockService: MemberServiceProtocol {
+        func fetchMembers() async throws -> [Member] { [] }
+        func addMember(_ input: AddMemberInput) async throws {}
+    }
+
+    @Test func groupingByRole() {
+        let service = MockService()
+        let vm = MembersListViewModel(service: service, currentUserId: "1")
+        vm.members = [
+            Member(id: "1", displayName: "Alice", email: "a", role: .lead, isDeleted: false, deletedAt: nil),
+            Member(id: "2", displayName: "Bob", email: "b", role: .member, isDeleted: false, deletedAt: nil)
+        ]
+        vm.groupOption = .role
+        let groups = vm.groupedMembers()
+        #expect(groups.count == 2)
+        #expect(groups.first?.title == "Lead")
+    }
+
+    @Test func defaultSortPinsCurrentUser() {
+        let service = MockService()
+        let vm = MembersListViewModel(service: service, currentUserId: "2")
+        vm.members = [
+            Member(id: "1", displayName: "A", email: "", role: .member, isDeleted: false, deletedAt: nil),
+            Member(id: "2", displayName: "B", email: "", role: .member, isDeleted: false, deletedAt: nil)
+        ]
+        let sorted = vm.sortedMembers()
+        #expect(sorted.first?.id == "2")
+    }
+
+    @Test func userSortRemovesPin() {
+        let service = MockService()
+        let vm = MembersListViewModel(service: service, currentUserId: "2")
+        vm.members = [
+            Member(id: "1", displayName: "A", email: "", role: .lead, isDeleted: false, deletedAt: nil),
+            Member(id: "2", displayName: "B", email: "", role: .member, isDeleted: false, deletedAt: nil)
+        ]
+        vm.sort.toggleOrSelect(.role)
+        let sorted = vm.sortedMembers()
+        #expect(sorted.first?.id == "1")
+    }
+}


### PR DESCRIPTION
## Summary
- implement `MemberGroupOption` and `MemberSortField`
- expand `MembersListViewModel` with grouping & sorting logic
- replace `MembersListView` with groupable list view and add menu controls
- pass current user ID through the router to enable pinning
- add tests for `MembersListViewModel`

## Testing
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a3d2a8cc832fb24e2064bbc231b1