### PR TITLE
Add PhotoPicker with metadata extraction

### DIFF
--- a/App/FreshWall/FreshWallApp/Clients/ClientsListView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientsListView.swift
@@ -71,7 +71,6 @@ struct ClientsListView: View {
         photoService: incidentPhotoService,
         clientModelService: clientModelService,
         userModelService: userModelService,
-        metadataService: PhotoMetadataService(),
         session: session
     )
     FreshWallPreview {

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoPicker.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoPicker.swift
@@ -1,0 +1,106 @@
+import _PhotosUI_SwiftUI
+import CoreLocation
+import PhotosUI
+import SwiftUI
+
+// MARK: - PickedPhoto
+
+/// A photo selected from ``PhotoPicker`` along with optional metadata.
+struct PickedPhoto: Identifiable, Sendable {
+    /// Unique identifier for the selection.
+    let id = UUID()
+    /// Chosen image.
+    let image: UIImage
+    /// Date when the photo was captured, if available.
+    let captureDate: Date?
+    /// Location where the photo was captured, if available.
+    let location: CLLocation?
+
+    /// Create a ``PickedPhoto`` from raw image data using a metadata service.
+    /// - Parameters:
+    ///   - data: Raw image bytes.
+    ///   - service: Service used to extract metadata.
+    /// - Returns: A ``PickedPhoto`` if the data can be converted to an image.
+    static func make(
+        from data: Data,
+        using service: PhotoMetadataServiceProtocol
+    ) -> PickedPhoto? {
+        guard let image = UIImage(data: data) else { return nil }
+        let meta = service.metadata(from: data)
+        return PickedPhoto(image: image, captureDate: meta.captureDate, location: meta.location)
+    }
+}
+
+// MARK: - PhotoPicker
+
+/// A wrapper around ``PhotosPicker`` that loads selected images and their metadata.
+struct PhotoPicker<Label: View>: View {
+    @Binding private var selection: [PickedPhoto]
+    private let metadataService: PhotoMetadataServiceProtocol
+
+    private var maxSelectionCount: Int?
+    private var selectionBehavior: PhotosPickerSelectionBehavior
+    private var filter: PHPickerFilter?
+    private var preferredItemEncoding: PhotosPickerItem.EncodingDisambiguationPolicy
+    private var photoLibrary: PHPhotoLibrary
+    private let label: () -> Label
+
+    @State private var items: [PhotosPickerItem] = []
+
+    init(
+        selection: Binding<[PickedPhoto]>,
+        maxSelectionCount: Int? = nil,
+        selectionBehavior: PhotosPickerSelectionBehavior = .default,
+        matching filter: PHPickerFilter? = nil,
+        preferredItemEncoding: PhotosPickerItem.EncodingDisambiguationPolicy = .automatic,
+        photoLibrary: PHPhotoLibrary,
+        metadataService: PhotoMetadataServiceProtocol = PhotoMetadataService(),
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        _selection = selection
+        self.maxSelectionCount = maxSelectionCount
+        self.selectionBehavior = selectionBehavior
+        self.filter = filter
+        self.preferredItemEncoding = preferredItemEncoding
+        self.photoLibrary = photoLibrary
+        self.metadataService = metadataService
+        self.label = label
+    }
+
+    var body: some View {
+        PhotosPicker(
+            selection: $items,
+            maxSelectionCount: maxSelectionCount,
+            selectionBehavior: selectionBehavior,
+            matching: filter,
+            preferredItemEncoding: preferredItemEncoding,
+            photoLibrary: photoLibrary,
+            label: label
+        )
+        .onChange(of: items) { _, newItems in
+            Task {
+                var newSelection: [PickedPhoto] = []
+                for item in newItems {
+                    if let data = try? await item.loadTransferable(type: Data.self),
+                       let photo = PickedPhoto.make(from: data, using: metadataService) {
+                        newSelection.append(photo)
+                    }
+                }
+                selection = newSelection
+            }
+        }
+    }
+}
+
+#Preview {
+    @State var photos: [PickedPhoto] = []
+
+    return FreshWallPreview {
+        VStack {
+            PhotoPicker(selection: $photos, photoLibrary: .shared()) {
+                Label("Select Photos", systemImage: "photo")
+            }
+            Text("Selected: \(photos.count)")
+        }
+    }
+}

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoPicker.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoPicker.swift
@@ -21,7 +21,7 @@ struct PickedPhoto: Identifiable, Sendable {
     ///   - data: Raw image bytes.
     ///   - service: Service used to extract metadata.
     /// - Returns: A ``PickedPhoto`` if the data can be converted to an image.
-    init(id: String = UUID().uuidString, image: UIImage, captureDate: Date?, location: CLLocation?) {
+    init(id: String, image: UIImage, captureDate: Date?, location: CLLocation?) {
         self.id = id
         self.image = image
         self.captureDate = captureDate
@@ -34,6 +34,7 @@ struct PickedPhoto: Identifiable, Sendable {
         using service: PhotoMetadataServiceProtocol
     ) -> PickedPhoto? {
         guard let image = UIImage(data: data) else { return nil }
+
         let meta = service.metadata(from: data)
         return PickedPhoto(id: id, image: image, captureDate: meta.captureDate, location: meta.location)
     }

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
@@ -10,10 +10,8 @@ struct AddIncidentView: View {
     @Environment(RouterPath.self) private var routerPath
     @State var viewModel: AddIncidentViewModel
     private let addNewTag = "__ADD_NEW__"
-    @State private var beforePickerItems: [PhotosPickerItem] = []
-    @State private var afterPickerItems: [PhotosPickerItem] = []
-    @State private var beforeImages: [UIImage] = []
-    @State private var afterImages: [UIImage] = []
+    @State private var beforePhotos: [PickedPhoto] = []
+    @State private var afterPhotos: [PickedPhoto] = []
 
     /// Initializes the view with a view model.
     init(viewModel: AddIncidentViewModel) {
@@ -79,12 +77,12 @@ struct AddIncidentView: View {
                 TextEditor(text: $viewModel.input.materialsUsed)
                     .frame(minHeight: 80)
             }
-            if !beforeImages.isEmpty {
+            if !beforePhotos.isEmpty {
                 Section("Before Photos") {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack {
-                            ForEach(beforeImages.indices, id: \.self) { idx in
-                                Image(uiImage: beforeImages[idx])
+                            ForEach(beforePhotos.indices, id: \.self) { idx in
+                                Image(uiImage: beforePhotos[idx].image)
                                     .resizable()
                                     .scaledToFill()
                                     .frame(width: 100, height: 100)
@@ -95,15 +93,15 @@ struct AddIncidentView: View {
                     .frame(height: 120)
                 }
             }
-            PhotosPicker(selection: $beforePickerItems, matching: .images, photoLibrary: .shared()) {
+            PhotoPicker(selection: $beforePhotos, matching: .images, photoLibrary: .shared()) {
                 Label("Add Before Photos", systemImage: "photo.on.rectangle")
             }
-            if !afterImages.isEmpty {
+            if !afterPhotos.isEmpty {
                 Section("After Photos") {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack {
-                            ForEach(afterImages.indices, id: \.self) { idx in
-                                Image(uiImage: afterImages[idx])
+                            ForEach(afterPhotos.indices, id: \.self) { idx in
+                                Image(uiImage: afterPhotos[idx].image)
                                     .resizable()
                                     .scaledToFill()
                                     .frame(width: 100, height: 100)
@@ -114,7 +112,7 @@ struct AddIncidentView: View {
                     .frame(height: 120)
                 }
             }
-            PhotosPicker(selection: $afterPickerItems, matching: .images, photoLibrary: .shared()) {
+            PhotoPicker(selection: $afterPhotos, matching: .images, photoLibrary: .shared()) {
                 Label("Add After Photos", systemImage: "photo.fill.on.rectangle.fill")
             }
         }
@@ -124,8 +122,8 @@ struct AddIncidentView: View {
                 Button("Save") {
                     Task {
                         do {
-                            let beforeData = beforeImages.compactMap { $0.jpegData(compressionQuality: 0.8) }
-                            let afterData = afterImages.compactMap { $0.jpegData(compressionQuality: 0.8) }
+                            let beforeData = beforePhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }
+                            let afterData = afterPhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }
                             try await viewModel.save(beforeImages: beforeData, afterImages: afterData)
                             dismiss()
                         } catch {
@@ -138,28 +136,6 @@ struct AddIncidentView: View {
         }
         .task {
             await viewModel.loadClients()
-        }
-        .onChange(of: beforePickerItems) { _, newItems in
-            Task {
-                beforeImages = []
-                for item in newItems {
-                    if let data = try? await item.loadTransferable(type: Data.self),
-                       let image = UIImage(data: data) {
-                        beforeImages.append(image)
-                    }
-                }
-            }
-        }
-        .onChange(of: afterPickerItems) { _, newItems in
-            Task {
-                afterImages = []
-                for item in newItems {
-                    if let data = try? await item.loadTransferable(type: Data.self),
-                       let image = UIImage(data: data) {
-                        afterImages.append(image)
-                    }
-                }
-            }
         }
     }
 }

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
@@ -122,9 +122,7 @@ struct AddIncidentView: View {
                 Button("Save") {
                     Task {
                         do {
-                            let beforeData = beforePhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }
-                            let afterData = afterPhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }
-                            try await viewModel.save(beforeImages: beforeData, afterImages: afterData)
+                            try await viewModel.save(beforePhotos: beforePhotos, afterPhotos: afterPhotos)
                             dismiss()
                         } catch {
                             // Handle error if needed
@@ -149,14 +147,14 @@ private class PreviewIncidentService: IncidentServiceProtocol {
     func addIncident(_: Incident) async throws {}
     func addIncident(
         _: AddIncidentInput,
-        beforeImages _: [Data],
-        afterImages _: [Data]
+        beforePhotos _: [PickedPhoto],
+        afterPhotos _: [PickedPhoto]
     ) async throws {}
     func updateIncident(
         _: String,
         with _: UpdateIncidentInput,
-        beforeImages _: [Data],
-        afterImages _: [Data]
+        beforePhotos _: [PickedPhoto],
+        afterPhotos _: [PickedPhoto]
     ) async throws {}
 }
 

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
@@ -51,7 +51,7 @@ final class AddIncidentViewModel {
     }
 
     /// Saves the new incident via the service along with photo data.
-    func save(beforeImages: [Data], afterImages: [Data]) async throws {
+    func save(beforePhotos: [PickedPhoto], afterPhotos: [PickedPhoto]) async throws {
         let areaValue = Double(input.areaText) ?? 0
         let rateValue = Double(input.rateText)
         let input = AddIncidentInput(
@@ -68,8 +68,8 @@ final class AddIncidentViewModel {
         )
         try await service.addIncident(
             input,
-            beforeImages: beforeImages,
-            afterImages: afterImages
+            beforePhotos: beforePhotos,
+            afterPhotos: afterPhotos
         )
     }
 

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
@@ -73,12 +73,12 @@ struct EditIncidentView: View {
                 TextEditor(text: $viewModel.materialsUsed)
                     .frame(minHeight: 80)
             }
-            if !viewModel.beforeImages.isEmpty {
+            if !viewModel.beforePhotos.isEmpty {
                 Section("Before Photos") {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack {
-                            ForEach(viewModel.beforeImages.indices, id: \.self) { idx in
-                                Image(uiImage: viewModel.beforeImages[idx])
+                            ForEach(viewModel.beforePhotos.indices, id: \.self) { idx in
+                                Image(uiImage: viewModel.beforePhotos[idx].image)
                                     .resizable()
                                     .scaledToFill()
                                     .frame(width: 100, height: 100)
@@ -89,15 +89,15 @@ struct EditIncidentView: View {
                     .frame(height: 120)
                 }
             }
-            PhotosPicker(selection: $viewModel.beforePickerItems, matching: .images, photoLibrary: .shared()) {
+            PhotoPicker(selection: $viewModel.beforePhotos, matching: .images, photoLibrary: .shared()) {
                 Label("Add Before Photos", systemImage: "photo.on.rectangle")
             }
-            if !viewModel.afterImages.isEmpty {
+            if !viewModel.afterPhotos.isEmpty {
                 Section("After Photos") {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack {
-                            ForEach(viewModel.afterImages.indices, id: \.self) { idx in
-                                Image(uiImage: viewModel.afterImages[idx])
+                            ForEach(viewModel.afterPhotos.indices, id: \.self) { idx in
+                                Image(uiImage: viewModel.afterPhotos[idx].image)
                                     .resizable()
                                     .scaledToFill()
                                     .frame(width: 100, height: 100)
@@ -108,7 +108,7 @@ struct EditIncidentView: View {
                     .frame(height: 120)
                 }
             }
-            PhotosPicker(selection: $viewModel.afterPickerItems, matching: .images, photoLibrary: .shared()) {
+            PhotoPicker(selection: $viewModel.afterPhotos, matching: .images, photoLibrary: .shared()) {
                 Label("Add After Photos", systemImage: "photo.fill.on.rectangle.fill")
             }
         }
@@ -121,8 +121,8 @@ struct EditIncidentView: View {
                 Button("Save") {
                     Task {
                         do {
-                            let beforeData = viewModel.beforeImages.compactMap { $0.jpegData(compressionQuality: 0.8) }
-                            let afterData = viewModel.afterImages.compactMap { $0.jpegData(compressionQuality: 0.8) }
+                            let beforeData = viewModel.beforePhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }
+                            let afterData = viewModel.afterPhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }
                             try await viewModel.save(beforeImages: beforeData, afterImages: afterData)
                             dismiss()
                         } catch {}
@@ -134,28 +134,7 @@ struct EditIncidentView: View {
         .task {
             await viewModel.loadClients()
         }
-        .onChange(of: viewModel.beforePickerItems) { _, newItems in
-            Task {
-                viewModel.beforeImages = []
-                for item in newItems {
-                    if let data = try? await item.loadTransferable(type: Data.self),
-                       let image = UIImage(data: data) {
-                        viewModel.beforeImages.append(image)
-                    }
-                }
-            }
-        }
-        .onChange(of: viewModel.afterPickerItems) { _, newItems in
-            Task {
-                viewModel.afterImages = []
-                for item in newItems {
-                    if let data = try? await item.loadTransferable(type: Data.self),
-                       let image = UIImage(data: data) {
-                        viewModel.afterImages.append(image)
-                    }
-                }
-            }
-        }
+        
     }
 }
 

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
@@ -135,7 +135,6 @@ struct EditIncidentView: View {
         .task {
             await viewModel.loadClients()
         }
-        
     }
 }
 

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
@@ -121,9 +121,10 @@ struct EditIncidentView: View {
                 Button("Save") {
                     Task {
                         do {
-                            let beforeData = viewModel.beforePhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }
-                            let afterData = viewModel.afterPhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }
-                            try await viewModel.save(beforeImages: beforeData, afterImages: afterData)
+                            try await viewModel.save(
+                                beforePhotos: viewModel.beforePhotos,
+                                afterPhotos: viewModel.afterPhotos
+                            )
                             dismiss()
                         } catch {}
                     }
@@ -168,14 +169,14 @@ private class PreviewIncidentService: IncidentServiceProtocol {
     func addIncident(_: Incident) async throws {}
     func addIncident(
         _: AddIncidentInput,
-        beforeImages _: [Data],
-        afterImages _: [Data]
+        beforePhotos _: [PickedPhoto],
+        afterPhotos _: [PickedPhoto]
     ) async throws {}
     func updateIncident(
         _: String,
         with _: UpdateIncidentInput,
-        beforeImages _: [Data],
-        afterImages _: [Data]
+        beforePhotos _: [PickedPhoto],
+        afterPhotos _: [PickedPhoto]
     ) async throws {}
 }
 

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
@@ -27,14 +27,10 @@ final class EditIncidentViewModel {
     var status: String
     /// Materials used description.
     var materialsUsed: String
-    /// Picker selections for before photos.
-    var beforePickerItems: [PhotosPickerItem] = []
-    /// Picker selections for after photos.
-    var afterPickerItems: [PhotosPickerItem] = []
-    /// Images chosen for before state.
-    var beforeImages: [UIImage] = []
-    /// Images chosen for after state.
-    var afterImages: [UIImage] = []
+    /// Photos selected to represent the "before" state.
+    var beforePhotos: [PickedPhoto] = []
+    /// Photos selected to represent the "after" state.
+    var afterPhotos: [PickedPhoto] = []
     /// Status options for selection.
     let statusOptions = ["open", "in_progress", "completed"]
     /// Loaded clients for selection.

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
@@ -64,7 +64,7 @@ final class EditIncidentViewModel {
     }
 
     /// Saves the updated incident using the service along with new photos.
-    func save(beforeImages: [Data], afterImages: [Data]) async throws {
+    func save(beforePhotos: [PickedPhoto], afterPhotos: [PickedPhoto]) async throws {
         let input = UpdateIncidentInput(
             clientId: clientId.trimmingCharacters(in: .whitespaces),
             description: description,
@@ -80,8 +80,8 @@ final class EditIncidentViewModel {
         try await service.updateIncident(
             incidentId,
             with: input,
-            beforeImages: beforeImages,
-            afterImages: afterImages
+            beforePhotos: beforePhotos,
+            afterPhotos: afterPhotos
         )
     }
 

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListView.swift
@@ -100,8 +100,8 @@ struct IncidentsListView: View {
 private class PreviewIncidentService: IncidentServiceProtocol {
     func fetchIncidents() async throws -> [Incident] { [] }
     func addIncident(_: Incident) async throws {}
-    func addIncident(_: AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
-    func updateIncident(_: String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
+    func addIncident(_: AddIncidentInput, beforePhotos _: [PickedPhoto], afterPhotos _: [PickedPhoto]) async throws {}
+    func updateIncident(_: String, with _: UpdateIncidentInput, beforePhotos _: [PickedPhoto], afterPhotos _: [PickedPhoto]) async throws {}
 }
 
 // MARK: - PreviewClientService

--- a/App/FreshWall/FreshWallApp/MainAppView.swift
+++ b/App/FreshWall/FreshWallApp/MainAppView.swift
@@ -37,7 +37,6 @@ struct MainAppView: View {
             photoService: incidentPhotoService,
             clientModelService: clientModelService,
             userModelService: userModelService,
-            metadataService: PhotoMetadataService(),
             session: sessionStore.session
         )
 

--- a/App/FreshWall/FreshWallApp/Models/IncidentPhoto.swift
+++ b/App/FreshWall/FreshWallApp/Models/IncidentPhoto.swift
@@ -6,6 +6,8 @@ import Foundation
 
 /// Domain model representing a photo with optional metadata.
 struct IncidentPhoto: Sendable {
+    /// Identifier used to match the DTO representation.
+    var id: String
     /// Download URL for the photo.
     var url: String
     /// Date when the photo was captured.
@@ -30,6 +32,7 @@ extension IncidentPhoto: Hashable, Equatable {
 extension IncidentPhoto {
     /// Create a domain model from a DTO.
     init(dto: IncidentPhotoDTO) {
+        id = dto.id
         url = dto.url
         captureDate = dto.captureDate?.dateValue()
         if let point = dto.location {
@@ -42,6 +45,7 @@ extension IncidentPhoto {
     /// Convert the domain model to a DTO for persistence.
     var dto: IncidentPhotoDTO {
         IncidentPhotoDTO(
+            id: id,
             url: url,
             captureDate: captureDate.map { Timestamp(date: $0) },
             location: location.map { GeoPoint(latitude: $0.latitude, longitude: $0.longitude) }

--- a/App/FreshWall/FreshWallApp/Models/IncidentPhotoDTO.swift
+++ b/App/FreshWall/FreshWallApp/Models/IncidentPhotoDTO.swift
@@ -5,6 +5,8 @@ import Foundation
 
 /// Metadata and storage info for an incident photo persisted in Firestore.
 struct IncidentPhotoDTO: Codable, Hashable, Sendable {
+    /// Unique identifier for the photo entry.
+    var id: String
     /// Download URL for the photo.
     var url: String
     /// When the photo was captured if available.
@@ -16,7 +18,7 @@ struct IncidentPhotoDTO: Codable, Hashable, Sendable {
 extension IncidentPhotoDTO {
     /// Dictionary representation for use with Firestore update operations.
     var dictionary: [String: Any] {
-        var dict: [String: Any] = ["url": url]
+        var dict: [String: Any] = ["id": id, "url": url]
         if let captureDate { dict["captureDate"] = captureDate }
         if let location { dict["location"] = location }
         return dict

--- a/App/FreshWall/FreshWallApp/Models/PickedPhoto+IncidentDTO.swift
+++ b/App/FreshWall/FreshWallApp/Models/PickedPhoto+IncidentDTO.swift
@@ -17,7 +17,7 @@ extension IncidentPhotoDTO {
     }
 }
 
-extension Array where Element == PickedPhoto {
+extension [PickedPhoto] {
     /// Convert the photos into DTOs pairing each item with the given URLs.
     /// - Parameter urls: Storage URLs matching the photo order.
     /// - Returns: DTOs ready for persistence.

--- a/App/FreshWall/FreshWallApp/Models/PickedPhoto+IncidentDTO.swift
+++ b/App/FreshWall/FreshWallApp/Models/PickedPhoto+IncidentDTO.swift
@@ -1,0 +1,28 @@
+import CoreLocation
+@preconcurrency import FirebaseFirestore
+import Foundation
+
+extension IncidentPhotoDTO {
+    /// Create an incident photo DTO from a URL and a ``PickedPhoto``.
+    /// - Parameters:
+    ///   - url: Storage URL for the photo.
+    ///   - photo: The selected photo with metadata.
+    init(url: String, photo: PickedPhoto) {
+        self.url = url
+        self.captureDate = photo.captureDate.map { Timestamp(date: $0) }
+        self.location = photo.location.map {
+            GeoPoint(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude)
+        }
+    }
+}
+
+extension Array where Element == PickedPhoto {
+    /// Convert the photos into DTOs pairing each item with the given URLs.
+    /// - Parameter urls: Storage URLs matching the photo order.
+    /// - Returns: DTOs ready for persistence.
+    func toIncidentPhotoDTOs(urls: [String]) -> [IncidentPhotoDTO] {
+        zip(self, urls).map { photo, url in
+            IncidentPhotoDTO(url: url, photo: photo)
+        }
+    }
+}

--- a/App/FreshWall/FreshWallApp/Models/PickedPhoto+IncidentDTO.swift
+++ b/App/FreshWall/FreshWallApp/Models/PickedPhoto+IncidentDTO.swift
@@ -8,6 +8,7 @@ extension IncidentPhotoDTO {
     ///   - url: Storage URL for the photo.
     ///   - photo: The selected photo with metadata.
     init(url: String, photo: PickedPhoto) {
+        self.id = photo.id.uuidString
         self.url = url
         self.captureDate = photo.captureDate.map { Timestamp(date: $0) }
         self.location = photo.location.map {

--- a/App/FreshWall/FreshWallApp/Models/PickedPhoto+IncidentDTO.swift
+++ b/App/FreshWall/FreshWallApp/Models/PickedPhoto+IncidentDTO.swift
@@ -8,7 +8,7 @@ extension IncidentPhotoDTO {
     ///   - url: Storage URL for the photo.
     ///   - photo: The selected photo with metadata.
     init(url: String, photo: PickedPhoto) {
-        self.id = photo.id.uuidString
+        self.id = photo.id
         self.url = url
         self.captureDate = photo.captureDate.map { Timestamp(date: $0) }
         self.location = photo.location.map {

--- a/App/FreshWall/FreshWallApp/Services/IncidentService.swift
+++ b/App/FreshWall/FreshWallApp/Services/IncidentService.swift
@@ -97,21 +97,9 @@ struct IncidentService: IncidentServiceProtocol {
             images: afterData
         )
 
-        let beforePhotosDTO = zip(beforePhotos, beforeUrls).map { photo, url -> IncidentPhotoDTO in
-            IncidentPhotoDTO(
-                url: url,
-                captureDate: photo.captureDate.map { Timestamp(date: $0) },
-                location: photo.location.map { GeoPoint(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude) }
-            )
-        }
+        let beforePhotosDTO = beforePhotos.toIncidentPhotoDTOs(urls: beforeUrls)
 
-        let afterPhotosDTO = zip(afterPhotos, afterUrls).map { photo, url -> IncidentPhotoDTO in
-            IncidentPhotoDTO(
-                url: url,
-                captureDate: photo.captureDate.map { Timestamp(date: $0) },
-                location: photo.location.map { GeoPoint(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude) }
-            )
-        }
+        let afterPhotosDTO = afterPhotos.toIncidentPhotoDTOs(urls: afterUrls)
 
         let newIncident = IncidentDTO(
             id: newDoc.documentID,
@@ -183,14 +171,9 @@ struct IncidentService: IncidentServiceProtocol {
             incidentId: incidentId,
             images: beforeData
         )
-        let beforePhotoDicts = zip(beforePhotos, newBeforeUrls).map { photo, url -> [String: Any] in
-            let dto = IncidentPhotoDTO(
-                url: url,
-                captureDate: photo.captureDate.map { Timestamp(date: $0) },
-                location: photo.location.map { GeoPoint(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude) }
-            )
-            return dto.dictionary
-        }
+        let beforePhotoDicts = beforePhotos
+            .toIncidentPhotoDTOs(urls: newBeforeUrls)
+            .map(\.dictionary)
         if !beforePhotoDicts.isEmpty {
             data["beforePhotos"] = FieldValue.arrayUnion(beforePhotoDicts)
         }
@@ -201,14 +184,9 @@ struct IncidentService: IncidentServiceProtocol {
             incidentId: incidentId,
             images: afterData
         )
-        let afterPhotoDicts = zip(afterPhotos, newAfterUrls).map { photo, url -> [String: Any] in
-            let dto = IncidentPhotoDTO(
-                url: url,
-                captureDate: photo.captureDate.map { Timestamp(date: $0) },
-                location: photo.location.map { GeoPoint(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude) }
-            )
-            return dto.dictionary
-        }
+        let afterPhotoDicts = afterPhotos
+            .toIncidentPhotoDTOs(urls: newAfterUrls)
+            .map(\.dictionary)
         if !afterPhotoDicts.isEmpty {
             data["afterPhotos"] = FieldValue.arrayUnion(afterPhotoDicts)
         }

--- a/App/FreshWall/FreshWallTests/ClientsListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/ClientsListViewModelTests.swift
@@ -13,8 +13,8 @@ struct ClientsListViewModelTests {
     final class MockIncidentService: IncidentServiceProtocol {
         func fetchIncidents() async throws -> [Incident] { [] }
         func addIncident(_: Incident) async throws {}
-        func addIncident(_: AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
-        func updateIncident(_: String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
+        func addIncident(_: AddIncidentInput, beforePhotos _: [PickedPhoto], afterPhotos _: [PickedPhoto]) async throws {}
+        func updateIncident(_: String, with _: UpdateIncidentInput, beforePhotos _: [PickedPhoto], afterPhotos _: [PickedPhoto]) async throws {}
     }
 
     @Test func sortAlphabeticalAscending() {

--- a/App/FreshWall/FreshWallTests/EditIncidentViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/EditIncidentViewModelTests.swift
@@ -10,14 +10,14 @@ struct EditIncidentViewModelTests {
         func addIncident(_: Incident) async throws {}
         func addIncident(
             _: AddIncidentInput,
-            beforeImages _: [Data],
-            afterImages _: [Data]
+            beforePhotos _: [PickedPhoto],
+            afterPhotos _: [PickedPhoto]
         ) async throws {}
         func updateIncident(
             _ id: String,
             with input: UpdateIncidentInput,
-            beforeImages _: [Data],
-            afterImages _: [Data]
+            beforePhotos _: [PickedPhoto],
+            afterPhotos _: [PickedPhoto]
         ) async throws {
             updateArgs = (id, input)
         }
@@ -88,7 +88,7 @@ struct EditIncidentViewModelTests {
         )
         let vm = EditIncidentViewModel(incident: incident, incidentService: incidentService, clientService: clientService)
         vm.description = "new"
-        try await vm.save(beforeImages: [], afterImages: [])
+        try await vm.save(beforePhotos: [], afterPhotos: [])
         #expect(incidentService.updateArgs?.0 == "1")
         #expect(incidentService.updateArgs?.1.description == "new")
     }

--- a/App/FreshWall/FreshWallTests/IncidentServiceCompositionTests.swift
+++ b/App/FreshWall/FreshWallTests/IncidentServiceCompositionTests.swift
@@ -18,7 +18,6 @@ struct IncidentServiceCompositionTests {
         func uploadAfterPhotos(teamId _: String, incidentId _: String, images: [Data]) async throws -> [String] { images.map { _ in "after" } }
     }
 
-
     final actor MockClientModel: ClientModelServiceProtocol {
         var requested: (String, String)?
         func fetchClients(teamId _: String, sortedBy _: ClientSortOption) async throws -> [ClientDTO] { [] }

--- a/App/FreshWall/FreshWallTests/IncidentServiceCompositionTests.swift
+++ b/App/FreshWall/FreshWallTests/IncidentServiceCompositionTests.swift
@@ -18,10 +18,6 @@ struct IncidentServiceCompositionTests {
         func uploadAfterPhotos(teamId _: String, incidentId _: String, images: [Data]) async throws -> [String] { images.map { _ in "after" } }
     }
 
-    actor MockMeta: PhotoMetadataServiceProtocol {
-        func metadata(for _: PhotosPickerItem) async throws -> PhotoMetadata { PhotoMetadata(captureDate: nil, location: nil) }
-        func metadata(from _: Data) -> PhotoMetadata { PhotoMetadata(captureDate: nil, location: nil) }
-    }
 
     final actor MockClientModel: ClientModelServiceProtocol {
         var requested: (String, String)?
@@ -54,13 +50,15 @@ struct IncidentServiceCompositionTests {
             photoService: photo,
             clientModelService: clientModel,
             userModelService: userModel,
-            metadataService: MockMeta(),
             session: session
         )
         let input = AddIncidentInput(
             clientId: "c", description: "d", area: 1, startTime: .init(), endTime: .init(), billable: false, rate: nil, projectTitle: "", status: "open", materialsUsed: nil
         )
-        try await service.addIncident(input, beforeImages: [Data()], afterImages: [])
+        let renderer = UIGraphicsImageRenderer(size: .init(width: 1, height: 1))
+        let image = renderer.image { _ in }
+        let photo = PickedPhoto(image: image, captureDate: nil, location: nil)
+        try await service.addIncident(input, beforePhotos: [photo], afterPhotos: [])
         let added = await model.added
         let clientArgs = await clientModel.requested
         let userArgs = await userModel.requested

--- a/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
+++ b/App/FreshWall/FreshWallTests/IncidentsListViewModelTests.swift
@@ -7,8 +7,8 @@ struct IncidentsListViewModelTests {
     final class MockService: IncidentServiceProtocol {
         func fetchIncidents() async throws -> [Incident] { [] }
         func addIncident(_: Incident) async throws {}
-        func addIncident(_: AddIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
-        func updateIncident(_: String, with _: UpdateIncidentInput, beforeImages _: [Data], afterImages _: [Data]) async throws {}
+        func addIncident(_: AddIncidentInput, beforePhotos _: [PickedPhoto], afterPhotos _: [PickedPhoto]) async throws {}
+        func updateIncident(_: String, with _: UpdateIncidentInput, beforePhotos _: [PickedPhoto], afterPhotos _: [PickedPhoto]) async throws {}
     }
 
     final class MockClientService: ClientServiceProtocol {

--- a/App/FreshWall/FreshWallTests/PhotoPickerTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoPickerTests.swift
@@ -50,6 +50,7 @@ struct PhotoPickerTests {
         let image = renderer.image { _ in }
         let photo = PickedPhoto(image: image, captureDate: .distantPast, location: CLLocation(latitude: 1, longitude: 2))
         let dtos = [photo].toIncidentPhotoDTOs(urls: ["url"])
+        #expect(dtos.first?.id == photo.id.uuidString)
         #expect(dtos.first?.url == "url")
         #expect(dtos.first?.captureDate?.dateValue() == .distantPast)
         #expect(dtos.first?.location?.latitude == 1)

--- a/App/FreshWall/FreshWallTests/PhotoPickerTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoPickerTests.swift
@@ -1,0 +1,47 @@
+import _PhotosUI_SwiftUI
+@testable import FreshWall
+import Testing
+import UniformTypeIdentifiers
+
+struct PhotoPickerTests {
+    private func makeTestImageData() -> Data {
+        let width = 1
+        let height = 1
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+        var pixel: [UInt8] = [255, 0, 0, 255]
+        let provider = CGDataProvider(data: Data(pixel) as CFData)!
+        let cgImage = CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        )!
+
+        let metaData = NSMutableData()
+        let dest = CGImageDestinationCreateWithData(metaData, UTType.jpeg.identifier as CFString, 1, nil)!
+        let exif: [CFString: Any] = [kCGImagePropertyExifDateTimeOriginal: "2023:12:31 10:00:00"]
+        CGImageDestinationAddImage(dest, cgImage, [kCGImagePropertyExifDictionary: exif] as CFDictionary)
+        CGImageDestinationFinalize(dest)
+        return metaData as Data
+    }
+
+    final actor MockMeta: PhotoMetadataServiceProtocol {
+        func metadata(for _: PhotosPickerItem) async throws -> PhotoMetadata { PhotoMetadata(captureDate: .distantPast, location: nil) }
+        func metadata(from _: Data) -> PhotoMetadata { PhotoMetadata(captureDate: .distantPast, location: nil) }
+    }
+
+    @Test func createPickedPhotoFromData() {
+        let data = makeTestImageData()
+        let photo = PickedPhoto.make(from: data, using: MockMeta())
+        #expect(photo?.captureDate == .distantPast)
+        #expect(photo?.image.size.width == 1)
+    }
+}

--- a/App/FreshWall/FreshWallTests/PhotoPickerTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoPickerTests.swift
@@ -40,7 +40,7 @@ struct PhotoPickerTests {
 
     @Test func createPickedPhotoFromData() {
         let data = makeTestImageData()
-        let photo = PickedPhoto.make(from: data, using: MockMeta())
+        let photo = PickedPhoto.make(id: "id", from: data, using: MockMeta())
         #expect(photo?.captureDate == .distantPast)
         #expect(photo?.image.size.width == 1)
     }
@@ -48,9 +48,9 @@ struct PhotoPickerTests {
     @Test func convertPhotosToDTOs() {
         let renderer = UIGraphicsImageRenderer(size: .init(width: 1, height: 1))
         let image = renderer.image { _ in }
-        let photo = PickedPhoto(image: image, captureDate: .distantPast, location: CLLocation(latitude: 1, longitude: 2))
+        let photo = PickedPhoto(id: "p", image: image, captureDate: .distantPast, location: CLLocation(latitude: 1, longitude: 2))
         let dtos = [photo].toIncidentPhotoDTOs(urls: ["url"])
-        #expect(dtos.first?.id == photo.id.uuidString)
+        #expect(dtos.first?.id == photo.id)
         #expect(dtos.first?.url == "url")
         #expect(dtos.first?.captureDate?.dateValue() == .distantPast)
         #expect(dtos.first?.location?.latitude == 1)

--- a/App/FreshWall/FreshWallTests/PhotoPickerTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoPickerTests.swift
@@ -44,4 +44,15 @@ struct PhotoPickerTests {
         #expect(photo?.captureDate == .distantPast)
         #expect(photo?.image.size.width == 1)
     }
+
+    @Test func convertPhotosToDTOs() {
+        let renderer = UIGraphicsImageRenderer(size: .init(width: 1, height: 1))
+        let image = renderer.image { _ in }
+        let photo = PickedPhoto(image: image, captureDate: .distantPast, location: CLLocation(latitude: 1, longitude: 2))
+        let dtos = [photo].toIncidentPhotoDTOs(urls: ["url"])
+        #expect(dtos.first?.url == "url")
+        #expect(dtos.first?.captureDate?.dateValue() == .distantPast)
+        #expect(dtos.first?.location?.latitude == 1)
+        #expect(dtos.first?.location?.longitude == 2)
+    }
 }


### PR DESCRIPTION
## Summary
- implement `PhotoPicker` generic view that wraps `PhotosPicker`
- include `PickedPhoto` helper that bundles UIImage with capture date and location
- add preview for `PhotoPicker`
- test creating a `PickedPhoto` from image data
- start using `PickedPhoto` in `AddIncidentView` and `EditIncidentView`

## Testing
- `xcodebuild test -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584741e0b8832fa3fcec3bacc5e351