### PR TITLE
Improve incident photo viewer

### DIFF
--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoCarousel.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoCarousel.swift
@@ -44,7 +44,7 @@ struct PhotoCarousel: View {
 #Preview {
     let photos = [
         IncidentPhoto(id: "1", url: "https://via.placeholder.com/100", captureDate: nil, location: nil),
-        IncidentPhoto(id: "2", url: "https://via.placeholder.com/100/EEE", captureDate: nil, location: nil)
+        IncidentPhoto(id: "2", url: "https://via.placeholder.com/100/EEE", captureDate: nil, location: nil),
     ]
     return FreshWallPreview {
         PhotoCarousel(photos: photos) { _ in }

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoCarousel.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoCarousel.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// A horizontally scrollable carousel of photos.
+struct PhotoCarousel: View {
+    let photos: [IncidentPhoto]
+    let onSelect: (IncidentPhoto) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                ForEach(photos) { photo in
+                    Button {
+                        onSelect(photo)
+                    } label: {
+                        AsyncImage(url: URL(string: photo.url)) { phase in
+                            switch phase {
+                            case .empty:
+                                ProgressView()
+                                    .frame(width: 100, height: 100)
+                            case let .success(image):
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 100, height: 100)
+                                    .clipped()
+                            case .failure:
+                                Image(systemName: "photo")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 100, height: 100)
+                            @unknown default:
+                                EmptyView()
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .frame(height: 120)
+    }
+}
+
+#Preview {
+    let photos = [
+        IncidentPhoto(id: "1", url: "https://via.placeholder.com/100", captureDate: nil, location: nil),
+        IncidentPhoto(id: "2", url: "https://via.placeholder.com/100/EEE", captureDate: nil, location: nil)
+    ]
+    return FreshWallPreview {
+        PhotoCarousel(photos: photos) { _ in }
+    }
+}

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoCarousel.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoCarousel.swift
@@ -1,16 +1,17 @@
 import SwiftUI
 
-/// A horizontally scrollable carousel of photos.
+/// A horizontally scrollable carousel of photos that can launch a full-screen photo viewer.
 struct PhotoCarousel: View {
     let photos: [IncidentPhoto]
-    let onSelect: (IncidentPhoto) -> Void
+
+    @State private var viewerContext: PhotoViewerContext?
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 ForEach(photos) { photo in
                     Button {
-                        onSelect(photo)
+                        viewerContext = PhotoViewerContext(photos: photos, selectedPhoto: photo)
                     } label: {
                         AsyncImage(url: URL(string: photo.url)) { phase in
                             switch phase {
@@ -38,15 +39,8 @@ struct PhotoCarousel: View {
             }
         }
         .frame(height: 120)
-    }
-}
-
-#Preview {
-    let photos = [
-        IncidentPhoto(id: "1", url: "https://via.placeholder.com/100", captureDate: nil, location: nil),
-        IncidentPhoto(id: "2", url: "https://via.placeholder.com/100/EEE", captureDate: nil, location: nil),
-    ]
-    return FreshWallPreview {
-        PhotoCarousel(photos: photos) { _ in }
+        .fullScreenCover(item: $viewerContext) { context in
+            PhotoViewer(photos: context.photos, selectedPhoto: context.selectedPhoto)
+        }
     }
 }

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoCarousel.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoCarousel.swift
@@ -4,14 +4,15 @@ import SwiftUI
 struct PhotoCarousel: View {
     let photos: [IncidentPhoto]
 
-    @State private var viewerContext: PhotoViewerContext?
+    @Environment(RouterPath.self) private var routerPath
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 ForEach(photos) { photo in
                     Button {
-                        viewerContext = PhotoViewerContext(photos: photos, selectedPhoto: photo)
+                        let context = PhotoViewerContext(photos: photos, selectedPhoto: photo)
+                        routerPath.push(.photoViewer(context: context))
                     } label: {
                         AsyncImage(url: URL(string: photo.url)) { phase in
                             switch phase {
@@ -39,8 +40,5 @@ struct PhotoCarousel: View {
             }
         }
         .frame(height: 120)
-        .fullScreenCover(item: $viewerContext) { context in
-            PhotoViewer(photos: context.photos, selectedPhoto: context.selectedPhoto)
-        }
     }
 }

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoViewer.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoViewer.swift
@@ -26,27 +26,27 @@ struct PhotoViewer: View {
     var body: some View {
         TabView(selection: $index) {
             ForEach(Array(photos.enumerated()), id: \.element.id) { idx, photo in
-                AsyncImage(url: URL(string: photo.url)) { phase in
-                    switch phase {
-                    case .empty:
-                        ProgressView()
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .background(Color.black)
-                    case let .success(image):
-                        ZoomableImage(image: image)
-                            .tag(idx)
-                    case .failure:
-                        Image(systemName: "photo")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .background(Color.black)
-                            .tag(idx)
-                    @unknown default:
-                        EmptyView()
-                            .tag(idx)
+                ZStack {
+                    AsyncImage(url: URL(string: photo.url)) { phase in
+                        switch phase {
+                        case .empty:
+                            ProgressView()
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .background(Color.black)
+                        case let .success(image):
+                            ZoomableImage(image: image)
+                        case .failure:
+                            Image(systemName: "photo")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .background(Color.black)
+                        @unknown default:
+                            EmptyView()
+                        }
                     }
                 }
+                .tag(idx)
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .always))

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoViewer.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoViewer.swift
@@ -1,21 +1,19 @@
 import SwiftUI
 
+// MARK: - PhotoViewer
+
 /// Full screen photo viewer with paging and pinch-to-zoom support.
 struct PhotoViewer: View {
     let photos: [IncidentPhoto]
     @State private var index: Int
     @Environment(\.dismiss) private var dismiss
+    @State private var isZoomed = false
 
     init(photos: [IncidentPhoto], selectedPhoto: IncidentPhoto?) {
         self.photos = photos
         _index = State(initialValue: Self.initialIndex(photos: photos, selectedPhoto: selectedPhoto))
     }
 
-    /// Calculate the starting index for the viewer.
-    /// - Parameters:
-    ///   - photos: All available photos.
-    ///   - selectedPhoto: The photo the user tapped on.
-    /// - Returns: Index of `selectedPhoto` or `0` if not found.
     static func initialIndex(photos: [IncidentPhoto], selectedPhoto: IncidentPhoto?) -> Int {
         if let selectedPhoto, let idx = photos.firstIndex(of: selectedPhoto) {
             return idx
@@ -24,80 +22,56 @@ struct PhotoViewer: View {
     }
 
     var body: some View {
-        TabView(selection: $index) {
-            ForEach(Array(photos.enumerated()), id: \.element.id) { idx, photo in
-                ZStack {
-                    AsyncImage(url: URL(string: photo.url)) { phase in
-                        switch phase {
-                        case .empty:
-                            ProgressView()
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .background(Color.black)
-                        case let .success(image):
-                            ZoomableImage(image: image)
-                        case .failure:
-                            Image(systemName: "photo")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .background(Color.black)
-                        @unknown default:
-                            EmptyView()
+        ZStack(alignment: .topLeading) {
+            TabView(selection: $index) {
+                ForEach(Array(photos.enumerated()), id: \.element.id) { idx, photo in
+                    ZStack {
+                        AsyncImage(url: URL(string: photo.url)) { phase in
+                            switch phase {
+                            case .empty:
+                                ProgressView()
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                    .background(Color.black)
+                            case let .success(image):
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                                    .zoomable(
+                                        minZoomScale: 1,
+                                        doubleTapZoomScale: 3
+                                    )
+                            case .failure:
+                                Image(systemName: "photo")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                    .background(Color.black)
+                            @unknown default:
+                                EmptyView()
+                            }
                         }
                     }
+                    .tag(idx)
                 }
-                .tag(idx)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 28))
+                    .foregroundColor(.white)
+                    .padding()
             }
         }
-        .tabViewStyle(.page(indexDisplayMode: .always))
         .background(Color.black.ignoresSafeArea())
-        .onTapGesture { dismiss() }
-    }
-}
-
-/// Image that supports pinch and drag to zoom.
-private struct ZoomableImage: View {
-    var image: Image
-    @State private var scale: CGFloat = 1
-    @State private var lastScale: CGFloat = 1
-    @State private var offset: CGSize = .zero
-    @State private var lastOffset: CGSize = .zero
-
-    var body: some View {
-        image
-            .resizable()
-            .scaledToFit()
-            .scaleEffect(scale)
-            .offset(offset)
-            .gesture(
-                DragGesture()
-                    .onChanged { value in
-                        offset = CGSize(
-                            width: lastOffset.width + value.translation.width,
-                            height: lastOffset.height + value.translation.height
-                        )
-                    }
-                    .onEnded { _ in
-                        lastOffset = offset
-                    }
-            )
-            .gesture(
-                MagnificationGesture()
-                    .onChanged { value in
-                        scale = lastScale * value
-                    }
-                    .onEnded { _ in
-                        lastScale = scale
-                    }
-            )
-            .animation(.easeInOut, value: scale)
     }
 }
 
 #Preview {
     let photos = [
         IncidentPhoto(id: "1", url: "https://via.placeholder.com/600", captureDate: nil, location: nil),
-        IncidentPhoto(id: "2", url: "https://via.placeholder.com/600/EEE", captureDate: nil, location: nil)
+        IncidentPhoto(id: "2", url: "https://via.placeholder.com/600/EEE", captureDate: nil, location: nil),
     ]
     return FreshWallPreview {
         PhotoViewer(photos: photos, selectedPhoto: photos.first)

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoViewer.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoViewer.swift
@@ -6,7 +6,6 @@ import SwiftUI
 struct PhotoViewer: View {
     let photos: [IncidentPhoto]
     @State private var index: Int
-    @Environment(\.dismiss) private var dismiss
     @State private var isZoomed = false
 
     init(photos: [IncidentPhoto], selectedPhoto: IncidentPhoto?) {
@@ -22,48 +21,38 @@ struct PhotoViewer: View {
     }
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            TabView(selection: $index) {
-                ForEach(Array(photos.enumerated()), id: \.element.id) { idx, photo in
-                    ZStack {
-                        AsyncImage(url: URL(string: photo.url)) { phase in
-                            switch phase {
-                            case .empty:
-                                ProgressView()
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                    .background(Color.black)
-                            case let .success(image):
-                                image
-                                    .resizable()
-                                    .scaledToFit()
-                                    .zoomable(
-                                        minZoomScale: 1,
-                                        doubleTapZoomScale: 3
-                                    )
-                            case .failure:
-                                Image(systemName: "photo")
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                    .background(Color.black)
-                            @unknown default:
-                                EmptyView()
-                            }
+        TabView(selection: $index) {
+            ForEach(Array(photos.enumerated()), id: \.element.id) { idx, photo in
+                ZStack {
+                    AsyncImage(url: URL(string: photo.url)) { phase in
+                        switch phase {
+                        case .empty:
+                            ProgressView()
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .background(Color.black)
+                        case let .success(image):
+                            image
+                                .resizable()
+                                .scaledToFit()
+                                .zoomable(
+                                    minZoomScale: 1,
+                                    doubleTapZoomScale: 3
+                                )
+                        case .failure:
+                            Image(systemName: "photo")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .background(Color.black)
+                        @unknown default:
+                            EmptyView()
                         }
                     }
-                    .tag(idx)
                 }
-            }
-            .tabViewStyle(.page(indexDisplayMode: .always))
-            Button {
-                dismiss()
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 28))
-                    .foregroundColor(.white)
-                    .padding()
+                .tag(idx)
             }
         }
+        .tabViewStyle(.page(indexDisplayMode: .always))
         .background(Color.black.ignoresSafeArea())
     }
 }

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoViewer.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoViewer.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// Full screen photo viewer with paging and pinch-to-zoom support.
+struct PhotoViewer: View {
+    let photos: [IncidentPhoto]
+    @State private var index: Int
+    @Environment(\.dismiss) private var dismiss
+
+    init(photos: [IncidentPhoto], selectedPhoto: IncidentPhoto?) {
+        self.photos = photos
+        _index = State(initialValue: Self.initialIndex(photos: photos, selectedPhoto: selectedPhoto))
+    }
+
+    /// Calculate the starting index for the viewer.
+    /// - Parameters:
+    ///   - photos: All available photos.
+    ///   - selectedPhoto: The photo the user tapped on.
+    /// - Returns: Index of `selectedPhoto` or `0` if not found.
+    static func initialIndex(photos: [IncidentPhoto], selectedPhoto: IncidentPhoto?) -> Int {
+        if let selectedPhoto, let idx = photos.firstIndex(of: selectedPhoto) {
+            return idx
+        }
+        return 0
+    }
+
+    var body: some View {
+        TabView(selection: $index) {
+            ForEach(Array(photos.enumerated()), id: \.element.id) { idx, photo in
+                AsyncImage(url: URL(string: photo.url)) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .background(Color.black)
+                    case let .success(image):
+                        ZoomableImage(image: image)
+                            .tag(idx)
+                    case .failure:
+                        Image(systemName: "photo")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .background(Color.black)
+                            .tag(idx)
+                    @unknown default:
+                        EmptyView()
+                            .tag(idx)
+                    }
+                }
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .always))
+        .background(Color.black.ignoresSafeArea())
+        .onTapGesture { dismiss() }
+    }
+}
+
+/// Image that supports pinch and drag to zoom.
+private struct ZoomableImage: View {
+    var image: Image
+    @State private var scale: CGFloat = 1
+    @State private var lastScale: CGFloat = 1
+    @State private var offset: CGSize = .zero
+    @State private var lastOffset: CGSize = .zero
+
+    var body: some View {
+        image
+            .resizable()
+            .scaledToFit()
+            .scaleEffect(scale)
+            .offset(offset)
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        offset = CGSize(
+                            width: lastOffset.width + value.translation.width,
+                            height: lastOffset.height + value.translation.height
+                        )
+                    }
+                    .onEnded { _ in
+                        lastOffset = offset
+                    }
+            )
+            .gesture(
+                MagnificationGesture()
+                    .onChanged { value in
+                        scale = lastScale * value
+                    }
+                    .onEnded { _ in
+                        lastScale = scale
+                    }
+            )
+            .animation(.easeInOut, value: scale)
+    }
+}
+
+#Preview {
+    let photos = [
+        IncidentPhoto(id: "1", url: "https://via.placeholder.com/600", captureDate: nil, location: nil),
+        IncidentPhoto(id: "2", url: "https://via.placeholder.com/600/EEE", captureDate: nil, location: nil)
+    ]
+    return FreshWallPreview {
+        PhotoViewer(photos: photos, selectedPhoto: photos.first)
+    }
+}

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoViewerContext.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoViewerContext.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Selection information for ``PhotoViewer``.
-struct PhotoViewerContext: Identifiable {
+struct PhotoViewerContext: Identifiable, Hashable {
     var photos: [IncidentPhoto]
     var selectedPhoto: IncidentPhoto
     var id: String { selectedPhoto.id }

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoViewerContext.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoViewerContext.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Selection information for ``PhotoViewer``.
+struct PhotoViewerContext: Identifiable {
+    var photos: [IncidentPhoto]
+    var selectedPhoto: IncidentPhoto
+    var id: String { selectedPhoto.id }
+}

--- a/App/FreshWall/FreshWallApp/GenericViews/ZoomableModifer.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/ZoomableModifer.swift
@@ -1,0 +1,187 @@
+//
+//  ZoomableModifer.swift
+//  FreshWall
+//
+//  Created by Gage Halverson on 6/22/25.
+//
+
+import SwiftUI
+
+// MARK: - ZoomableModifier
+
+struct ZoomableModifier: ViewModifier {
+    let minZoomScale: CGFloat
+    let doubleTapZoomScale: CGFloat
+
+    @State private var lastTransform: CGAffineTransform = .identity
+    @State private var transform: CGAffineTransform = .identity
+    @State private var contentSize: CGSize = .zero
+
+    func body(content: Content) -> some View {
+        content
+            .background(alignment: .topLeading) {
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear {
+                            contentSize = proxy.size
+                        }
+                }
+            }
+            .animatableTransformEffect(transform)
+            .gesture(dragGesture, including: transform == .identity ? .none : .all)
+            .gesture(magnificationGesture)
+            .gesture(doubleTapGesture)
+    }
+
+    private var magnificationGesture: some Gesture {
+        MagnifyGesture(minimumScaleDelta: 0)
+            .onChanged { value in
+                let newTransform = CGAffineTransform.anchoredScale(
+                    scale: value.magnification,
+                    anchor: value.startAnchor.scaledBy(contentSize)
+                )
+
+                withAnimation(.interactiveSpring) {
+                    transform = lastTransform.concatenating(newTransform)
+                }
+            }
+            .onEnded { _ in
+                onEndGesture()
+            }
+    }
+
+    private var doubleTapGesture: some Gesture {
+        SpatialTapGesture(count: 2)
+            .onEnded { value in
+                let newTransform: CGAffineTransform =
+                    if transform.isIdentity {
+                        .anchoredScale(scale: doubleTapZoomScale, anchor: value.location)
+                    } else {
+                        .identity
+                    }
+
+                withAnimation(.linear(duration: 0.15)) {
+                    transform = newTransform
+                    lastTransform = newTransform
+                }
+            }
+    }
+
+    private var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                withAnimation(.interactiveSpring) {
+                    transform = lastTransform.translatedBy(
+                        x: value.translation.width / transform.scaleX,
+                        y: value.translation.height / transform.scaleY
+                    )
+                }
+            }
+            .onEnded { _ in
+                onEndGesture()
+            }
+    }
+
+    private func onEndGesture() {
+        let newTransform = limitTransform(transform)
+
+        withAnimation(.snappy(duration: 0.1)) {
+            transform = newTransform
+            lastTransform = newTransform
+        }
+    }
+
+    private func limitTransform(_ transform: CGAffineTransform) -> CGAffineTransform {
+        let scaleX = transform.scaleX
+        let scaleY = transform.scaleY
+
+        if scaleX < minZoomScale
+            || scaleY < minZoomScale {
+            return .identity
+        }
+
+        let maxX = contentSize.width * (scaleX - 1)
+        let maxY = contentSize.height * (scaleY - 1)
+
+        if transform.tx > 0
+            || transform.tx < -maxX
+            || transform.ty > 0
+            || transform.ty < -maxY {
+            let tx = min(max(transform.tx, -maxX), 0)
+            let ty = min(max(transform.ty, -maxY), 0)
+            var transform = transform
+            transform.tx = tx
+            transform.ty = ty
+            return transform
+        }
+
+        return transform
+    }
+}
+
+public extension View {
+    @ViewBuilder
+    func zoomable(
+        minZoomScale: CGFloat = 1,
+        doubleTapZoomScale: CGFloat = 3
+    ) -> some View {
+        modifier(ZoomableModifier(
+            minZoomScale: minZoomScale,
+            doubleTapZoomScale: doubleTapZoomScale
+        ))
+    }
+
+    @ViewBuilder
+    func zoomable(
+        minZoomScale: CGFloat = 1,
+        doubleTapZoomScale: CGFloat = 3,
+        outOfBoundsColor: Color = .clear
+    ) -> some View {
+        GeometryReader { _ in
+            ZStack {
+                outOfBoundsColor
+                self.zoomable(
+                    minZoomScale: minZoomScale,
+                    doubleTapZoomScale: doubleTapZoomScale
+                )
+            }
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func animatableTransformEffect(_ transform: CGAffineTransform) -> some View {
+        scaleEffect(
+            x: transform.scaleX,
+            y: transform.scaleY,
+            anchor: .zero
+        )
+        .offset(x: transform.tx, y: transform.ty)
+    }
+}
+
+private extension UnitPoint {
+    func scaledBy(_ size: CGSize) -> CGPoint {
+        .init(
+            x: x * size.width,
+            y: y * size.height
+        )
+    }
+}
+
+private extension CGAffineTransform {
+    static func anchoredScale(scale: CGFloat, anchor: CGPoint) -> CGAffineTransform {
+        CGAffineTransform(translationX: anchor.x, y: anchor.y)
+            .scaledBy(x: scale, y: scale)
+            .translatedBy(x: -anchor.x, y: -anchor.y)
+    }
+
+    var scaleX: CGFloat {
+        sqrt(a * a + c * c)
+    }
+
+    var scaleY: CGFloat {
+        sqrt(b * b + d * d)
+    }
+}

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
@@ -41,7 +41,6 @@ final class AddIncidentViewModel {
     /// Validation: requires a clientId, description, and project title.
     var isValid: Bool {
         !input.clientId.trimmingCharacters(in: .whitespaces).isEmpty &&
-            !input.description.trimmingCharacters(in: .whitespaces).isEmpty &&
             !input.projectTitle.trimmingCharacters(in: .whitespaces).isEmpty
     }
 

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -138,7 +138,7 @@ struct IncidentDetailView: View {
                 )
             }
         }
-        .fullScreenCover(item: $viewerContext) { context in
+        .sheet(item: $viewerContext) { context in
             PhotoViewer(photos: context.photos, selectedPhoto: context.selectedPhoto)
         }
         .task {

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -9,6 +9,8 @@ struct IncidentDetailView: View {
     @Environment(RouterPath.self) private var routerPath
     @State private var client: Client?
     @State private var showingEdit = false
+    @State private var viewerPhotos: [IncidentPhoto] = []
+    @State private var selectedPhoto: IncidentPhoto?
 
     init(incident: Incident, incidentService: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
         _incident = State(wrappedValue: incident)
@@ -98,26 +100,32 @@ struct IncidentDetailView: View {
                 Section("Before Photos") {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack {
-                            ForEach(beforePhotos, id: \.url) { photo in
-                                AsyncImage(url: URL(string: photo.url)) { phase in
-                                    switch phase {
-                                    case .empty:
-                                        ProgressView()
-                                    case let .success(image):
-                                        image
-                                            .resizable()
-                                            .scaledToFill()
-                                            .frame(width: 100, height: 100)
-                                            .clipped()
-                                    case .failure:
-                                        Image(systemName: "photo")
-                                            .resizable()
-                                            .scaledToFit()
-                                            .frame(width: 100, height: 100)
-                                    @unknown default:
-                                        EmptyView()
+                            ForEach(beforePhotos) { photo in
+                                Button {
+                                    viewerPhotos = beforePhotos
+                                    selectedPhoto = photo
+                                } label: {
+                                    AsyncImage(url: URL(string: photo.url)) { phase in
+                                        switch phase {
+                                        case .empty:
+                                            ProgressView()
+                                        case let .success(image):
+                                            image
+                                                .resizable()
+                                                .scaledToFill()
+                                                .frame(width: 100, height: 100)
+                                                .clipped()
+                                        case .failure:
+                                            Image(systemName: "photo")
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: 100, height: 100)
+                                        @unknown default:
+                                            EmptyView()
+                                        }
                                     }
                                 }
+                                .buttonStyle(.plain)
                             }
                         }
                     }
@@ -128,26 +136,32 @@ struct IncidentDetailView: View {
                 Section("After Photos") {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack {
-                            ForEach(afterPhotos, id: \.url) { photo in
-                                AsyncImage(url: URL(string: photo.url)) { phase in
-                                    switch phase {
-                                    case .empty:
-                                        ProgressView()
-                                    case let .success(image):
-                                        image
-                                            .resizable()
-                                            .scaledToFill()
-                                            .frame(width: 100, height: 100)
-                                            .clipped()
-                                    case .failure:
-                                        Image(systemName: "photo")
-                                            .resizable()
-                                            .scaledToFit()
-                                            .frame(width: 100, height: 100)
-                                    @unknown default:
-                                        EmptyView()
+                            ForEach(afterPhotos) { photo in
+                                Button {
+                                    viewerPhotos = afterPhotos
+                                    selectedPhoto = photo
+                                } label: {
+                                    AsyncImage(url: URL(string: photo.url)) { phase in
+                                        switch phase {
+                                        case .empty:
+                                            ProgressView()
+                                        case let .success(image):
+                                            image
+                                                .resizable()
+                                                .scaledToFill()
+                                                .frame(width: 100, height: 100)
+                                                .clipped()
+                                        case .failure:
+                                            Image(systemName: "photo")
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: 100, height: 100)
+                                        @unknown default:
+                                            EmptyView()
+                                        }
                                     }
                                 }
+                                .buttonStyle(.plain)
                             }
                         }
                     }
@@ -182,6 +196,9 @@ struct IncidentDetailView: View {
                     )
                 )
             }
+        }
+        .fullScreenCover(item: $selectedPhoto) { photo in
+            PhotoViewer(photos: viewerPhotos, selectedPhoto: photo)
         }
         .task {
             await loadClient()

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -9,7 +9,6 @@ struct IncidentDetailView: View {
     @Environment(RouterPath.self) private var routerPath
     @State private var client: Client?
     @State private var showingEdit = false
-    @State private var viewerContext: PhotoViewerContext?
 
     init(incident: Incident, incidentService: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
         _incident = State(wrappedValue: incident)
@@ -133,9 +132,6 @@ struct IncidentDetailView: View {
                     )
                 )
             }
-        }
-        .fullScreenCover(item: $viewerContext) { context in
-            PhotoViewer(photos: context.photos, selectedPhoto: context.selectedPhoto)
         }
         .task {
             await loadClient()

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -97,16 +97,12 @@ struct IncidentDetailView: View {
             }
             if let beforePhotos = incident.beforePhotos.nullIfEmpty {
                 Section("Before Photos") {
-                    PhotoCarousel(photos: beforePhotos) { photo in
-                        viewerContext = PhotoViewerContext(photos: beforePhotos, selectedPhoto: photo)
-                    }
+                    PhotoCarousel(photos: beforePhotos)
                 }
             }
             if let afterPhotos = incident.afterPhotos.nullIfEmpty {
                 Section("After Photos") {
-                    PhotoCarousel(photos: afterPhotos) { photo in
-                        viewerContext = PhotoViewerContext(photos: afterPhotos, selectedPhoto: photo)
-                    }
+                    PhotoCarousel(photos: afterPhotos)
                 }
             }
             if let client {
@@ -138,7 +134,7 @@ struct IncidentDetailView: View {
                 )
             }
         }
-        .sheet(item: $viewerContext) { context in
+        .fullScreenCover(item: $viewerContext) { context in
             PhotoViewer(photos: context.photos, selectedPhoto: context.selectedPhoto)
         }
         .task {

--- a/App/FreshWall/FreshWallApp/Models/IncidentPhoto.swift
+++ b/App/FreshWall/FreshWallApp/Models/IncidentPhoto.swift
@@ -5,7 +5,7 @@ import Foundation
 // MARK: - IncidentPhoto
 
 /// Domain model representing a photo with optional metadata.
-struct IncidentPhoto: Sendable {
+struct IncidentPhoto: Identifiable, Sendable {
     /// Identifier used to match the DTO representation.
     var id: String
     /// Download URL for the photo.

--- a/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
+++ b/App/FreshWall/FreshWallApp/Navigation/RouterPath.swift
@@ -36,6 +36,8 @@ enum RouterDestination: Hashable {
     /// Screen for adding a new member.
     case inviteMember
     case memberDetail(member: Member)
+    /// Screen for viewing a photo in full screen.
+    case photoViewer(context: PhotoViewerContext)
 }
 
 // swiftlint:disable cyclomatic_complexity
@@ -91,6 +93,8 @@ extension View {
                 InviteMemberView(service: InviteCodeService())
             case let .memberDetail(member):
                 MemberDetailView(member: member)
+            case let .photoViewer(context):
+                PhotoViewer(photos: context.photos, selectedPhoto: context.selectedPhoto)
             }
         }
     }

--- a/App/FreshWall/FreshWallTests/PhotoViewerContextTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoViewerContextTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import FreshWall
+
+struct PhotoViewerContextTests {
+    @Test func idMatchesSelectedPhoto() {
+        let photos = [IncidentPhoto(id: "1", url: "a", captureDate: nil, location: nil)]
+        let context = PhotoViewerContext(photos: photos, selectedPhoto: photos[0])
+        #expect(context.id == photos[0].id)
+    }
+}

--- a/App/FreshWall/FreshWallTests/PhotoViewerContextTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoViewerContextTests.swift
@@ -1,5 +1,5 @@
-import Testing
 @testable import FreshWall
+import Testing
 
 struct PhotoViewerContextTests {
     @Test func idMatchesSelectedPhoto() {

--- a/App/FreshWall/FreshWallTests/PhotoViewerTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoViewerTests.swift
@@ -1,11 +1,11 @@
-import Testing
 @testable import FreshWall
+import Testing
 
 struct PhotoViewerTests {
     @Test func initialIndexReturnsZeroWhenNoSelection() {
         let photos = [
             IncidentPhoto(id: "1", url: "a", captureDate: nil, location: nil),
-            IncidentPhoto(id: "2", url: "b", captureDate: nil, location: nil)
+            IncidentPhoto(id: "2", url: "b", captureDate: nil, location: nil),
         ]
         #expect(PhotoViewer.initialIndex(photos: photos, selectedPhoto: nil) == 0)
     }
@@ -13,7 +13,7 @@ struct PhotoViewerTests {
     @Test func initialIndexMatchesSelectedPhoto() {
         let photos = [
             IncidentPhoto(id: "1", url: "a", captureDate: nil, location: nil),
-            IncidentPhoto(id: "2", url: "b", captureDate: nil, location: nil)
+            IncidentPhoto(id: "2", url: "b", captureDate: nil, location: nil),
         ]
         #expect(PhotoViewer.initialIndex(photos: photos, selectedPhoto: photos[1]) == 1)
     }

--- a/App/FreshWall/FreshWallTests/PhotoViewerTests.swift
+++ b/App/FreshWall/FreshWallTests/PhotoViewerTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import FreshWall
+
+struct PhotoViewerTests {
+    @Test func initialIndexReturnsZeroWhenNoSelection() {
+        let photos = [
+            IncidentPhoto(id: "1", url: "a", captureDate: nil, location: nil),
+            IncidentPhoto(id: "2", url: "b", captureDate: nil, location: nil)
+        ]
+        #expect(PhotoViewer.initialIndex(photos: photos, selectedPhoto: nil) == 0)
+    }
+
+    @Test func initialIndexMatchesSelectedPhoto() {
+        let photos = [
+            IncidentPhoto(id: "1", url: "a", captureDate: nil, location: nil),
+            IncidentPhoto(id: "2", url: "b", captureDate: nil, location: nil)
+        ]
+        #expect(PhotoViewer.initialIndex(photos: photos, selectedPhoto: photos[1]) == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- add a PhotoViewer generic component with pinch-to-zoom
- show photos in full screen from IncidentDetailView
- make IncidentPhoto identifiable
- add tests covering PhotoViewer helper

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685866e8e444832f836fd354194e149e