### PR TITLE
Update client cell to show simple creation date

### DIFF
--- a/App/FreshWall/FreshWallApp/Clients/ClientListCell.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientListCell.swift
@@ -9,14 +9,8 @@ struct ClientListCell: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(client.name)
                 .font(.headline)
-            HStack {
-                Text("Created: \\(client.createdAt.dateValue(), style: .date)")
-                    .font(.subheadline)
-                Spacer()
-                Text(client.isDeleted ? "Deleted" : "Active")
-                    .font(.subheadline)
-                    .foregroundColor(client.isDeleted ? .red : .green)
-            }
+            Text(client.createdAt.dateValue(), style: .date)
+                .font(.subheadline)
             if let notes = client.notes, !notes.isEmpty {
                 Text(notes)
                     .font(.subheadline)


### PR DESCRIPTION
## Summary
- simplify ClientListCell so it only shows the client's creation date below the name

## Testing
- `npm run lint` *(fails: biome not found)*
- `npm run build` *(fails: cannot find module declarations)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685867c29e7c832f8466fb9fc66c5c0c