### PR TITLE
Make client optional for incidents

### DIFF
--- a/App/FreshWall/FreshWallApp/Clients/ClientDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientDetailView.swift
@@ -83,7 +83,7 @@ struct ClientDetailView: View {
         .navigationTitle("Client Details")
         .task {
             let all = await (try? incidentService.fetchIncidents()) ?? []
-            incidents = all.filter { $0.clientRef.documentID == client.id }
+            incidents = all.filter { $0.clientRef?.documentID == client.id }
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Client Details")

--- a/App/FreshWall/FreshWallApp/Clients/ClientsListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientsListViewModel.swift
@@ -64,7 +64,7 @@ final class ClientsListViewModel {
         guard let id = client.id else { return .distantPast }
 
         let dates = incidents
-            .filter { $0.clientRef.documentID == id }
+            .filter { $0.clientRef?.documentID == id }
             .map { $0.createdAt.dateValue() }
         return dates.max() ?? .distantPast
     }

--- a/App/FreshWall/FreshWallApp/Clients/Models/ClientCellModel.swift
+++ b/App/FreshWall/FreshWallApp/Clients/Models/ClientCellModel.swift
@@ -20,7 +20,7 @@ extension ClientCellModel {
             guard let id = client.id else { return nil }
 
             let lastDate = incidents
-                .filter { $0.clientRef.documentID == id }
+                .filter { $0.clientRef?.documentID == id }
                 .map { $0.createdAt.dateValue() }
                 .max() ?? Date.distantPast
             return ClientCellModel(

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentViewModel.swift
@@ -38,10 +38,9 @@ final class AddIncidentViewModel {
     private let clientService: ClientServiceProtocol
     private let service: IncidentServiceProtocol
 
-    /// Validation: requires a clientId, description, and project title.
+    /// Validation: requires a non-empty project title.
     var isValid: Bool {
-        !input.clientId.trimmingCharacters(in: .whitespaces).isEmpty &&
-            !input.projectTitle.trimmingCharacters(in: .whitespaces).isEmpty
+        !input.projectTitle.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     init(service: IncidentServiceProtocol, clientService: ClientServiceProtocol) {
@@ -53,8 +52,9 @@ final class AddIncidentViewModel {
     func save(beforePhotos: [PickedPhoto], afterPhotos: [PickedPhoto]) async throws {
         let areaValue = Double(input.areaText) ?? 0
         let rateValue = Double(input.rateText)
+        let trimmedId = input.clientId.trimmingCharacters(in: .whitespaces)
         let input = AddIncidentInput(
-            clientId: input.clientId.trimmingCharacters(in: .whitespaces),
+            clientId: trimmedId.isEmpty ? nil : trimmedId,
             description: input.description,
             area: areaValue,
             startTime: input.startTime,

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentViewModel.swift
@@ -51,7 +51,7 @@ final class EditIncidentViewModel {
         incidentId = incident.id ?? ""
         service = incidentService
         self.clientService = clientService
-        clientId = incident.clientRef.documentID
+        clientId = incident.clientRef?.documentID ?? ""
         description = incident.description
         areaText = String(incident.area)
         startTime = incident.startTime.dateValue()

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -30,7 +30,7 @@ struct IncidentDetailView: View {
     /// Loads the client associated with this incident.
     private func loadClient() async {
         let clients = await (try? clientService.fetchClients(sortedBy: .createdAtAscending)) ?? []
-        client = clients.first { $0.id == incident.clientRef.documentID }
+        client = clients.first { $0.id == incident.clientRef?.documentID }
     }
 
     var body: some View {

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
@@ -57,7 +57,7 @@ final class IncidentsListViewModel {
             }
             return groups
                 .map { key, value in
-                    let name = clients.first { $0.id == key }?.name ?? "Unknown"
+                    let name = clients.first { $0.id == key }?.name ?? "No Client"
                     return (title: name, items: sort(value))
                 }
                 .sorted { lhs, rhs in

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentsListViewModel.swift
@@ -53,7 +53,7 @@ final class IncidentsListViewModel {
             return [(nil, sorted)]
         case .client:
             let groups = Dictionary(grouping: incidents) { incident in
-                incident.clientRef.documentID
+                incident.clientRef?.documentID ?? ""
             }
             return groups
                 .map { key, value in

--- a/App/FreshWall/FreshWallApp/Models/Incident.swift
+++ b/App/FreshWall/FreshWallApp/Models/Incident.swift
@@ -7,7 +7,7 @@ import Foundation
 struct Incident: Identifiable, Hashable, Sendable {
     var id: String?
     var projectTitle: String
-    var clientRef: DocumentReference
+    var clientRef: DocumentReference?
     var workerRefs: [DocumentReference]
     var description: String
     var area: Double

--- a/App/FreshWall/FreshWallApp/Models/IncidentDTO.swift
+++ b/App/FreshWall/FreshWallApp/Models/IncidentDTO.swift
@@ -9,8 +9,8 @@ struct IncidentDTO: Codable, Identifiable, Sendable, Hashable {
     @DocumentID var id: String?
     /// Title describing the project for this incident.
     var projectTitle: String
-    /// Reference to the client document associated with this incident.
-    var clientRef: DocumentReference
+    /// Reference to the client document associated with this incident, optional when not yet assigned.
+    var clientRef: DocumentReference?
     /// References to worker user documents involved in this incident.
     var workerRefs: [DocumentReference]
     /// Notes describing the incident.

--- a/App/FreshWall/FreshWallApp/Services/IncidentService.swift
+++ b/App/FreshWall/FreshWallApp/Services/IncidentService.swift
@@ -80,7 +80,9 @@ struct IncidentService: IncidentServiceProtocol {
         let teamId = session.teamId
 
         let newDoc = modelService.newIncidentDocument(teamId: teamId)
-        let clientRef = clientModelService.clientDocument(teamId: teamId, clientId: input.clientId)
+        let clientRef = input.clientId.map { id in
+            clientModelService.clientDocument(teamId: teamId, clientId: id)
+        }
         let uid = Auth.auth().currentUser?.uid ?? ""
         let createdByRef = userModelService.userDocument(teamId: teamId, userId: uid)
         let beforeData = beforePhotos.compactMap { $0.image.jpegData(compressionQuality: 0.8) }

--- a/App/FreshWall/FreshWallApp/Services/Input Models/AddIncidentInput.swift
+++ b/App/FreshWall/FreshWallApp/Services/Input Models/AddIncidentInput.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Input model for creating a new incident via `IncidentService`.
 struct AddIncidentInput: Sendable {
-    /// Document ID of the associated client.
-    let clientId: String
+    /// Document ID of the associated client, if one has been selected.
+    let clientId: String?
     /// Description of the incident.
     let description: String
     /// Area affected by the incident (sq ft).


### PR DESCRIPTION
## Summary
- allow creating incidents without an associated client
- update services and models for optional client reference
- adjust views and view models to handle a missing client

## Testing
- `swift test --enable-code-coverage` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6858e15aaa5c832fabe994d8d101219d