### PR TITLE
Auto login after signup

### DIFF
--- a/App/FreshWall/FreshWallApp/Auth/LoginManager.swift
+++ b/App/FreshWall/FreshWallApp/Auth/LoginManager.swift
@@ -78,6 +78,17 @@ struct LoginManager: LoginManaging {
             displayName: displayName,
             teamName: teamName
         )
+
+        guard let user = authService.getCurrentUser() else {
+            throw NSError(
+                domain: "LoginManager",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "User not logged in after sign up"]
+            )
+        }
+
+        let session = try await sessionService.fetchUserRecord(for: user)
+        await sessionStore.startSession(session)
     }
 
     func signUp(
@@ -92,5 +103,16 @@ struct LoginManager: LoginManaging {
             displayName: displayName,
             teamCode: teamCode
         )
+
+        guard let user = authService.getCurrentUser() else {
+            throw NSError(
+                domain: "LoginManager",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "User not logged in after sign up"]
+            )
+        }
+
+        let session = try await sessionService.fetchUserRecord(for: user)
+        await sessionStore.startSession(session)
     }
 }


### PR DESCRIPTION
## Summary
- auto start session after user creates an account

## Testing
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e8b9c834832f8c15c880d004c6be