### PR TITLE
Add pull-to-refresh for all detail views

### DIFF
--- a/App/FreshWall/FreshWallApp/Clients/ClientDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Clients/ClientDetailView.swift
@@ -85,6 +85,11 @@ struct ClientDetailView: View {
             let all = await (try? incidentService.fetchIncidents()) ?? []
             incidents = all.filter { $0.clientRef?.documentID == client.id }
         }
+        .refreshable {
+            await reloadClient()
+            let all = await (try? incidentService.fetchIncidents()) ?? []
+            incidents = all.filter { $0.clientRef?.documentID == client.id }
+        }
         .listStyle(.insetGrouped)
         .navigationTitle("Client Details")
         .toolbar {

--- a/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/IncidentDetailView.swift
@@ -117,6 +117,9 @@ struct IncidentDetailView: View {
         .task {
             await loadClient()
         }
+        .refreshable {
+            await reloadIncident()
+        }
     }
 }
 

--- a/App/FreshWall/FreshWallApp/Members/MemberDetailView.swift
+++ b/App/FreshWall/FreshWallApp/Members/MemberDetailView.swift
@@ -37,6 +37,9 @@ struct MemberDetailView: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle("Member Details")
+        .refreshable {
+            // No-op until member service supports reloading a single member
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- support pull-to-refresh on ClientDetailView
- support pull-to-refresh on IncidentDetailView
- add placeholder refresh on MemberDetailView

## Testing
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ee191af0832fb6cb876e7019c998