### PR TITLE
Add camera option for photo picker

### DIFF
--- a/App/FreshWall/FreshWall.xcodeproj/project.pbxproj
+++ b/App/FreshWall/FreshWall.xcodeproj/project.pbxproj
@@ -808,6 +808,7 @@
 				INFOPLIST_FILE = "FreshWall-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = FreshWall;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.business";
+				INFOPLIST_KEY_NSCameraUsageDescription = "ability for user to take photos of the graffati";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -854,6 +855,7 @@
 				INFOPLIST_FILE = "FreshWall-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = FreshWall;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.business";
+				INFOPLIST_KEY_NSCameraUsageDescription = "ability for user to take photos of the graffati";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -1229,6 +1231,7 @@
 				INFOPLIST_FILE = "FreshWall-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = FreshWall;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.business";
+				INFOPLIST_KEY_NSCameraUsageDescription = "ability for user to take photos of the graffati";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/App/FreshWall/FreshWallApp/GenericViews/CameraPicker.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/CameraPicker.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import UIKit
+
+/// A camera capture view using `UIImagePickerController`.
+struct CameraPicker: UIViewControllerRepresentable {
+    /// Completion handler providing JPEG data for the captured image.
+    var onImagePicked: (Data?) -> Void
+
+    final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        private let parent: CameraPicker
+
+        init(parent: CameraPicker) {
+            self.parent = parent
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            defer { parent.onImagePicked(parent.extractData(from: info)) }
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.onImagePicked(nil)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_: UIImagePickerController, context _: Context) {}
+
+    private func extractData(from info: [UIImagePickerController.InfoKey: Any]) -> Data? {
+        guard let image = info[.originalImage] as? UIImage else { return nil }
+        return image.jpegData(compressionQuality: 0.8)
+    }
+}
+

--- a/App/FreshWall/FreshWallApp/GenericViews/CameraPicker.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/CameraPicker.swift
@@ -13,11 +13,14 @@ struct CameraPicker: UIViewControllerRepresentable {
             self.parent = parent
         }
 
-        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        func imagePickerController(
+            _: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
             defer { parent.onImagePicked(parent.extractData(from: info)) }
         }
 
-        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        func imagePickerControllerDidCancel(_: UIImagePickerController) {
             parent.onImagePicked(nil)
         }
     }
@@ -37,7 +40,7 @@ struct CameraPicker: UIViewControllerRepresentable {
 
     private func extractData(from info: [UIImagePickerController.InfoKey: Any]) -> Data? {
         guard let image = info[.originalImage] as? UIImage else { return nil }
+
         return image.jpegData(compressionQuality: 0.8)
     }
 }
-

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoPicker.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoPicker.swift
@@ -6,7 +6,7 @@ import SwiftUI
 // MARK: - PickedPhoto
 
 /// A photo selected from ``PhotoPicker`` along with optional metadata.
-struct PickedPhoto: Identifiable, Sendable {
+struct PickedPhoto: Identifiable, Sendable, Equatable {
     /// Unique identifier for the selection.
     let id: String
     /// Chosen image.

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoSourcePicker.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoSourcePicker.swift
@@ -1,0 +1,75 @@
+import PhotosUI
+import SwiftUI
+
+/// A button that presents a menu allowing the user to choose the camera or the photo library.
+struct PhotoSourcePicker<Label: View>: View {
+    @Binding private var selection: [PickedPhoto]
+    private let metadataService: PhotoMetadataServiceProtocol
+    private let maxSelectionCount: Int?
+    private let selectionBehavior: PhotosPickerSelectionBehavior
+    private let filter: PHPickerFilter?
+    private let preferredItemEncoding: PhotosPickerItem.EncodingDisambiguationPolicy
+    private let photoLibrary: PHPhotoLibrary
+    private let label: () -> Label
+
+    @State private var showDialog = false
+    @State private var showCamera = false
+    @State private var librarySelection: [PickedPhoto] = []
+
+    init(
+        selection: Binding<[PickedPhoto]>,
+        maxSelectionCount: Int? = nil,
+        selectionBehavior: PhotosPickerSelectionBehavior = .default,
+        matching filter: PHPickerFilter? = nil,
+        preferredItemEncoding: PhotosPickerItem.EncodingDisambiguationPolicy = .automatic,
+        photoLibrary: PHPhotoLibrary,
+        metadataService: PhotoMetadataServiceProtocol = PhotoMetadataService(),
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        _selection = selection
+        self.maxSelectionCount = maxSelectionCount
+        self.selectionBehavior = selectionBehavior
+        self.filter = filter
+        self.preferredItemEncoding = preferredItemEncoding
+        self.photoLibrary = photoLibrary
+        self.metadataService = metadataService
+        self.label = label
+    }
+
+    var body: some View {
+        Button(action: { showDialog = true }, label: label)
+            .confirmationDialog("Add Photo", isPresented: $showDialog) {
+                Button("Camera") { showCamera = true }
+                PhotoPicker(
+                    selection: $librarySelection,
+                    maxSelectionCount: maxSelectionCount,
+                    selectionBehavior: selectionBehavior,
+                    matching: filter,
+                    preferredItemEncoding: preferredItemEncoding,
+                    photoLibrary: photoLibrary,
+                    metadataService: metadataService
+                ) {
+                    Text("Photo Library")
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+            .sheet(isPresented: $showCamera) {
+                CameraPicker { data in
+                    if let data,
+                       let photo = PickedPhoto.make(
+                           id: UUID().uuidString,
+                           from: data,
+                           using: metadataService
+                       ) {
+                        selection.append(photo)
+                    }
+                    showCamera = false
+                }
+            }
+            .onChange(of: librarySelection) { _, newValue in
+                selection.append(contentsOf: newValue)
+                librarySelection.removeAll()
+            }
+    }
+}
+

--- a/App/FreshWall/FreshWallApp/GenericViews/PhotoSourcePicker.swift
+++ b/App/FreshWall/FreshWallApp/GenericViews/PhotoSourcePicker.swift
@@ -53,7 +53,7 @@ struct PhotoSourcePicker<Label: View>: View {
                 preferredItemEncoding: preferredItemEncoding,
                 photoLibrary: photoLibrary
             )
-            .sheet(isPresented: $showCamera) {
+            .fullScreenCover(isPresented: $showCamera) {
                 CameraPicker { data in
                     if let data,
                        let photo = PickedPhoto.make(
@@ -65,6 +65,7 @@ struct PhotoSourcePicker<Label: View>: View {
                     }
                     showCamera = false
                 }
+                .ignoresSafeArea()
             }
             .onChange(of: libraryItems) { _, newItems in
                 Task {
@@ -85,4 +86,3 @@ struct PhotoSourcePicker<Label: View>: View {
             }
     }
 }
-

--- a/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/AddIncidentView.swift
@@ -51,7 +51,7 @@ struct AddIncidentView: View {
                     .frame(height: 120)
                 }
             }
-            PhotoPicker(selection: $beforePhotos, matching: .images, photoLibrary: .shared()) {
+            PhotoSourcePicker(selection: $beforePhotos, matching: .images, photoLibrary: .shared()) {
                 Label("Add Before Photos", systemImage: "photo.on.rectangle")
             }
             if !afterPhotos.isEmpty {
@@ -70,7 +70,7 @@ struct AddIncidentView: View {
                     .frame(height: 120)
                 }
             }
-            PhotoPicker(selection: $afterPhotos, matching: .images, photoLibrary: .shared()) {
+            PhotoSourcePicker(selection: $afterPhotos, matching: .images, photoLibrary: .shared()) {
                 Label("Add After Photos", systemImage: "photo.fill.on.rectangle.fill")
             }
             Section(header: Text("Timeframe")) {

--- a/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
+++ b/App/FreshWall/FreshWallApp/Incidents/EditIncidentView.swift
@@ -89,7 +89,7 @@ struct EditIncidentView: View {
                     .frame(height: 120)
                 }
             }
-            PhotoPicker(selection: $viewModel.beforePhotos, matching: .images, photoLibrary: .shared()) {
+            PhotoSourcePicker(selection: $viewModel.beforePhotos, matching: .images, photoLibrary: .shared()) {
                 Label("Add Before Photos", systemImage: "photo.on.rectangle")
             }
             if !viewModel.afterPhotos.isEmpty {
@@ -108,7 +108,7 @@ struct EditIncidentView: View {
                     .frame(height: 120)
                 }
             }
-            PhotoPicker(selection: $viewModel.afterPhotos, matching: .images, photoLibrary: .shared()) {
+            PhotoSourcePicker(selection: $viewModel.afterPhotos, matching: .images, photoLibrary: .shared()) {
                 Label("Add After Photos", systemImage: "photo.fill.on.rectangle.fill")
             }
         }

--- a/App/FreshWall/FreshWallTests/CameraPickerTests.swift
+++ b/App/FreshWall/FreshWallTests/CameraPickerTests.swift
@@ -1,0 +1,23 @@
+@testable import FreshWall
+import UIKit
+import Testing
+
+struct CameraPickerTests {
+    @Test func makeControllerUsesCamera() {
+        let picker = CameraPicker { _ in }
+        let context = CameraPicker.Context(coordinator: picker.makeCoordinator())
+        let controller = picker.makeUIViewController(context: context)
+        #expect(controller.sourceType == .camera)
+    }
+
+    @Test func coordinatorCallsCompletion() {
+        var called = false
+        let picker = CameraPicker { _ in called = true }
+        let coordinator = picker.makeCoordinator()
+        coordinator.imagePickerController(
+            UIImagePickerController(),
+            didFinishPickingMediaWithInfo: [.originalImage: UIImage()]
+        )
+        #expect(called)
+    }
+}


### PR DESCRIPTION
## Summary
- create `CameraPicker` for capturing photos with `UIImagePickerController`
- present camera or photo library options with `PhotoSourcePicker`
- use new menu when adding incident photos
- test `CameraPicker`

## Testing
- `xcodebuild -scheme FreshWallApp -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*
- `swift test` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c4e3ec6f8832f8b201056b9885947